### PR TITLE
fix: LangChain tracer semconv parity with langchain-azure-ai

### DIFF
--- a/samples/validate_traces.py
+++ b/samples/validate_traces.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+E2E validation: verifies the LangChain tracer produces spans that comply
+with the OTel GenAI semantic conventions.
+
+Uses FakeListLLM (no API key needed).
+"""
+
+import os
+import sys
+
+# Enable content capture for validation
+os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "SPAN_ONLY"
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import set_tracer_provider, SpanKind
+
+
+class MemoryExporter(SpanExporter):
+    def __init__(self):
+        self._spans = []
+
+    def export(self, spans):
+        self._spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def get_finished_spans(self):
+        return list(self._spans)
+
+    def shutdown(self):
+        pass
+
+
+def main():
+    mem = MemoryExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "e2e-validation"}))
+    provider.add_span_processor(SimpleSpanProcessor(mem))
+    set_tracer_provider(provider)
+
+    from microsoft.genai._langchain._tracer_instrumentor import LangChainInstrumentor
+
+    inst = LangChainInstrumentor()
+    inst.instrument(
+        tracer_provider=provider,
+        agent_name="TestAgent",
+        agent_id="agent-123",
+        agent_description="E2E test agent",
+        agent_version="1.0.0",
+        server_address="test.example.com",
+        server_port=443,
+    )
+
+    # ── Sample 1: Simple LLM call ───────────────────────────────────────
+    from langchain_community.llms.fake import FakeListLLM
+
+    llm = FakeListLLM(responses=["Paris is the capital of France."])
+    llm.invoke("What is the capital of France?")
+
+    # ── Sample 2: Chain (prompt → LLM → parser) ────────────────────────
+    from langchain_core.prompts import ChatPromptTemplate
+    from langchain_core.output_parsers import StrOutputParser
+
+    llm2 = FakeListLLM(responses=["42 is the answer."])
+    chain = ChatPromptTemplate.from_messages([
+        ("system", "You are helpful."),
+        ("human", "{q}"),
+    ]) | llm2 | StrOutputParser()
+    chain.invoke({"q": "What is 6*7?"})
+
+    # ── Sample 3: Tool invocation ───────────────────────────────────────
+    from langchain_core.tools import tool
+
+    @tool
+    def get_weather(location: str) -> str:
+        """Get the weather for a location."""
+        return f"Sunny, 72°F in {location}"
+
+    get_weather.invoke({"location": "San Francisco"})
+
+    # ── Flush and analyse ───────────────────────────────────────────────
+    provider.force_flush()
+    spans = mem.get_finished_spans()
+
+    llm_spans = [s for s in spans if s.attributes.get("gen_ai.operation.name") == "chat"]
+    tool_spans = [s for s in spans if s.attributes.get("gen_ai.operation.name") == "execute_tool"]
+
+    ok = True
+
+    def check(label, condition, detail=""):
+        nonlocal ok
+        status = "✅" if condition else "❌"
+        if not condition:
+            ok = False
+        print(f"  {status} {label}" + (f" — {detail}" if detail else ""))
+
+    # ── LLM span checks ────────────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print(f"LLM SPANS ({len(llm_spans)} found)")
+    print(f"{'='*60}")
+
+    for span in llm_spans:
+        attrs = span.attributes
+        print(f"\n  Span: {span.name}")
+        check("gen_ai.operation.name present", "gen_ai.operation.name" in attrs)
+        check("gen_ai.operation.name == 'chat'", attrs.get("gen_ai.operation.name") == "chat")
+        check("gen_ai.provider.name present", "gen_ai.provider.name" in attrs)
+        check("SpanKind is CLIENT", span.kind == SpanKind.CLIENT,
+              f"actual: {span.kind.name}")
+        check("Span name is not 'chat None'", "None" not in span.name,
+              f"actual: '{span.name}'")
+        check("gen_ai.response.finish_reasons present",
+              "gen_ai.response.finish_reasons" in attrs)
+
+    # ── Tool span checks ───────────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print(f"TOOL SPANS ({len(tool_spans)} found)")
+    print(f"{'='*60}")
+
+    for span in tool_spans:
+        attrs = span.attributes
+        print(f"\n  Span: {span.name}")
+        check("gen_ai.operation.name present", "gen_ai.operation.name" in attrs)
+        check("gen_ai.operation.name == 'execute_tool'",
+              attrs.get("gen_ai.operation.name") == "execute_tool")
+        check("gen_ai.tool.name present", "gen_ai.tool.name" in attrs)
+        check("gen_ai.tool.type == 'function'",
+              attrs.get("gen_ai.tool.type") == "function",
+              f"actual: {attrs.get('gen_ai.tool.type')}")
+        check("gen_ai.tool.description present", "gen_ai.tool.description" in attrs)
+        check("SpanKind is INTERNAL", span.kind == SpanKind.INTERNAL,
+              f"actual: {span.kind.name}")
+        check("Span name format 'execute_tool <name>'",
+              span.name.startswith("execute_tool "))
+        # Content capture enabled — args/results should be present
+        check("gen_ai.tool.call.arguments present (content on)",
+              "gen_ai.tool.call.arguments" in attrs)
+        check("gen_ai.tool.call.result present (content on)",
+              "gen_ai.tool.call.result" in attrs)
+
+    # ── All-span attribute dump ─────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print("ALL SPANS ATTRIBUTE DUMP")
+    print(f"{'='*60}")
+    for span in spans:
+        print(f"\n  [{span.kind.name}] {span.name}")
+        for k, v in sorted(span.attributes.items()):
+            val = repr(v) if len(repr(v)) < 120 else repr(v)[:120] + "..."
+            print(f"    {k} = {val}")
+
+    # ── Summary ─────────────────────────────────────────────────────────
+    print(f"\n{'='*60}")
+    if ok:
+        print("✅ ALL CHECKS PASSED")
+    else:
+        print("❌ SOME CHECKS FAILED")
+    print(f"{'='*60}")
+
+    inst.uninstrument()
+    provider.shutdown()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/microsoft/genai/_langchain/_tracer.py
+++ b/src/microsoft/genai/_langchain/_tracer.py
@@ -6,7 +6,7 @@
 import logging
 import re
 from collections import OrderedDict
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from itertools import chain
 from threading import RLock
 from typing import (
@@ -24,7 +24,7 @@ from opentelemetry.context import (
     _SUPPRESS_INSTRUMENTATION_KEY,
     get_value,
 )
-from opentelemetry.trace import Span
+from opentelemetry.trace import Span, SpanKind
 from opentelemetry.util.genai.span_utils import (
     _apply_error_attributes,
     _apply_llm_finish_attributes,
@@ -48,7 +48,10 @@ from microsoft.genai._langchain._utils import (
     GEN_AI_INPUT_MESSAGES_KEY,
     GEN_AI_OPERATION_NAME_KEY,
     GEN_AI_OUTPUT_MESSAGES_KEY,
+    GEN_AI_PROVIDER_NAME_KEY,
     GEN_AI_REQUEST_MODEL_KEY,
+    GEN_AI_USAGE_INPUT_TOKENS_KEY,
+    GEN_AI_USAGE_OUTPUT_TOKENS_KEY,
     SERVER_ADDRESS_KEY,
     SERVER_PORT_KEY,
     add_operation_type,
@@ -64,6 +67,8 @@ from microsoft.genai._langchain._utils import (
     model_name,
     output_messages,
     prompts,
+    _should_capture_content_on_spans,
+    token_counts,
     tools,
 )
 
@@ -167,16 +172,23 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
                 name=f"{INVOKE_AGENT_OPERATION_NAME} {wrapper_label}",
                 context=parent_context,
                 start_time=start_time_utc_nano,
+                kind=SpanKind.INTERNAL,
             )
             parent_context = trace_api.set_span_in_context(wrapper_span)
             # Resolve framework name for the inner span (e.g. "LangGraph")
             framework_name = self._resolve_framework_name(run)
             span_name = f"{INVOKE_AGENT_OPERATION_NAME} {framework_name}"
 
+        if run.run_type.lower() in ("llm", "chat_model"):
+            span_kind = SpanKind.CLIENT
+        else:
+            span_kind = SpanKind.INTERNAL
+
         span = self._tracer.start_span(
             name=span_name,
             context=parent_context,
             start_time=start_time_utc_nano,
+            kind=span_kind,
         )
 
         # For agent spans, set immediate attributes and init content aggregation
@@ -189,6 +201,10 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
                     "input_messages": [],
                     "output_messages": [],
                     "model": None,
+                    "provider": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "finish_reasons": [],
                 }
                 if wrapper_span is not None:
                     self._agent_wrapper_spans[run.id] = wrapper_span
@@ -201,6 +217,9 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
             agent_desc = self._agent_config.get("agent_description")
             if agent_desc:
                 agent_span.set_attribute(GEN_AI_AGENT_DESCRIPTION_KEY, agent_desc)
+            agent_version = self._agent_config.get("agent_version")
+            if agent_version:
+                agent_span.set_attribute("gen_ai.agent.version", agent_version)
             agent_span.set_attributes(dict(flatten(extract_agent_metadata(run))))
             server_addr = self._agent_config.get("server_address")
             if server_addr:
@@ -391,6 +410,19 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
                     content["model"] = m
                     break
 
+            if run_type in ("llm", "chat_model") and not content.get("provider"):
+                if run.extra and isinstance(run.extra, Mapping):
+                    meta = run.extra.get("metadata")
+                    if isinstance(meta, Mapping) and (ls_provider := meta.get("ls_provider")):
+                        content["provider"] = str(ls_provider).lower()
+
+            if run_type in ("llm", "chat_model") and run.outputs:
+                for key, val in token_counts(run.outputs):
+                    if key == GEN_AI_USAGE_INPUT_TOKENS_KEY and isinstance(val, int):
+                        content["input_tokens"] = content.get("input_tokens", 0) + val
+                    elif key == GEN_AI_USAGE_OUTPUT_TOKENS_KEY and isinstance(val, int):
+                        content["output_tokens"] = content.get("output_tokens", 0) + val
+
             # Capture input messages from LLM runs (first LLM child wins)
             if run_type in ("llm", "chat_model") and not content["input_messages"]:
                 if run.inputs:
@@ -445,23 +477,29 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
         if model := content.get("model"):
             span.set_attribute(GEN_AI_REQUEST_MODEL_KEY, model)
 
-        # Set aggregated input messages
-        if msgs := content.get("input_messages"):
-            span.set_attribute(GEN_AI_INPUT_MESSAGES_KEY, safe_json_dumps(msgs))
-        else:
-            # Fall back to run's own inputs
-            for _, val in invoke_agent_input_message(run.inputs):
-                span.set_attribute(GEN_AI_INPUT_MESSAGES_KEY, val)
-                break
+        if provider := content.get("provider"):
+            span.set_attribute(GEN_AI_PROVIDER_NAME_KEY, provider)
 
-        # Set aggregated output messages
-        if msgs := content.get("output_messages"):
-            span.set_attribute(GEN_AI_OUTPUT_MESSAGES_KEY, safe_json_dumps(msgs))
-        else:
-            # Fall back to run's own outputs
-            for _, val in invoke_agent_output_message(run.outputs):
-                span.set_attribute(GEN_AI_OUTPUT_MESSAGES_KEY, val)
-                break
+        if (input_tokens := content.get("input_tokens")) and input_tokens > 0:
+            span.set_attribute(GEN_AI_USAGE_INPUT_TOKENS_KEY, input_tokens)
+        if (output_tokens := content.get("output_tokens")) and output_tokens > 0:
+            span.set_attribute(GEN_AI_USAGE_OUTPUT_TOKENS_KEY, output_tokens)
+
+        # Set aggregated input/output messages only when content capture is enabled
+        if _should_capture_content_on_spans():
+            if msgs := content.get("input_messages"):
+                span.set_attribute(GEN_AI_INPUT_MESSAGES_KEY, safe_json_dumps(msgs))
+            else:
+                for _, val in invoke_agent_input_message(run.inputs):
+                    span.set_attribute(GEN_AI_INPUT_MESSAGES_KEY, val)
+                    break
+
+            if msgs := content.get("output_messages"):
+                span.set_attribute(GEN_AI_OUTPUT_MESSAGES_KEY, safe_json_dumps(msgs))
+            else:
+                for _, val in invoke_agent_output_message(run.outputs):
+                    span.set_attribute(GEN_AI_OUTPUT_MESSAGES_KEY, val)
+                    break
 
         # Set metadata (session_id, etc.)
         span.set_attributes(dict(flatten(metadata(run))))
@@ -493,6 +531,9 @@ def _update_span(span: Span, run: Run) -> LLMInvocation | None:
     if run_type in ("llm", "chat_model"):
         invocation = build_llm_invocation(run)
         _apply_llm_finish_attributes(span, invocation)
+        # Fix "chat None" span name when model is unknown
+        if invocation.request_model is None:
+            span.update_name(invocation.operation_name)
         # Extras not covered by LLMInvocation
         span.set_attributes(
             dict(

--- a/src/microsoft/genai/_langchain/_tracer_instrumentor.py
+++ b/src/microsoft/genai/_langchain/_tracer_instrumentor.py
@@ -63,6 +63,7 @@ class LangChainInstrumentor(BaseInstrumentor):
             "agent_name": kwargs.get("agent_name"),
             "agent_id": kwargs.get("agent_id"),
             "agent_description": kwargs.get("agent_description"),
+            "agent_version": kwargs.get("agent_version"),
             "server_address": kwargs.get("server_address"),
             "server_port": kwargs.get("server_port"),
         }
@@ -132,7 +133,16 @@ class _BaseCallbackManagerInit:
     ) -> None:
         wrapped(*args, **kwargs)
         if not any(isinstance(h, type(self._processor)) for h in instance.inheritable_handlers):
-            instance.add_handler(self._processor, inherit=True)
+            try:
+                instance.add_handler(self._processor, inherit=True)
+            except TypeError:
+                try:
+                    if hasattr(instance, "inheritable_handlers"):
+                        instance.inheritable_handlers.append(self._processor)
+                    elif hasattr(instance, "handlers"):
+                        instance.handlers.append(self._processor)
+                except Exception:
+                    logger.debug("Could not add tracer to callback manager", exc_info=True)
 
 
 # ------------------------------ Convenience APIs ------------------------------

--- a/src/microsoft/genai/_langchain/_utils.py
+++ b/src/microsoft/genai/_langchain/_utils.py
@@ -38,7 +38,12 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GenAiOperationNameValues,
 )
 from opentelemetry.semconv.attributes.server_attributes import SERVER_ADDRESS, SERVER_PORT
-from opentelemetry.util.genai.utils import gen_ai_json_dumps
+from opentelemetry.util.genai.utils import (
+    ContentCapturingMode,
+    gen_ai_json_dumps,
+    get_content_capturing_mode,
+    is_experimental_mode,
+)
 from opentelemetry.util.genai.types import (
     InputMessage,
     LLMInvocation,
@@ -49,10 +54,25 @@ from opentelemetry.util.genai.types import (
 from opentelemetry.util.types import AttributeValue
 from wrapt import ObjectProxy
 
+try:
+    from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+        GEN_AI_TOOL_DEFINITIONS,
+    )
+except ImportError:
+    GEN_AI_TOOL_DEFINITIONS = "gen_ai.tool.definitions"
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # ---- Core utilities ----------------------------------------------------------
+
+
+def _should_capture_content_on_spans() -> bool:
+    """Check if content should be captured on span attributes."""
+    if not is_experimental_mode():
+        return False
+    mode = get_content_capturing_mode()
+    return mode in (ContentCapturingMode.SPAN_ONLY, ContentCapturingMode.SPAN_AND_EVENT)
 
 
 def safe_json_dumps(obj: Any, **kwargs: Any) -> str:
@@ -182,6 +202,7 @@ GEN_AI_TOOL_DESCRIPTION_KEY = GEN_AI_TOOL_DESCRIPTION
 GEN_AI_TOOL_ARGS_KEY = GEN_AI_TOOL_CALL_ARGUMENTS
 GEN_AI_TOOL_CALL_RESULT_KEY = GEN_AI_TOOL_CALL_RESULT
 GEN_AI_TOOL_TYPE_KEY = GEN_AI_TOOL_TYPE
+GEN_AI_TOOL_DEFINITIONS_KEY = GEN_AI_TOOL_DEFINITIONS
 
 SESSION_ID_KEY = "microsoft.session.id"
 
@@ -302,7 +323,7 @@ def output_messages(
 
 @stop_on_exception
 def invocation_parameters(run: Run) -> Iterator[tuple[str, str]]:
-    if run.run_type.lower() != "llm":
+    if run.run_type.lower() not in ("llm", "chat_model"):
         return
     if not (extra := run.extra):
         return
@@ -311,9 +332,13 @@ def invocation_parameters(run: Run) -> Iterator[tuple[str, str]]:
     if inv_params := extra.get("invocation_params"):
         if not isinstance(inv_params, Mapping):
             return
-        tool_list = inv_params.get("tools", [])
-        for idx, tool in enumerate(tool_list):
-            yield f"{GEN_AI_TOOL_ARGS_KEY}.{idx}", safe_json_dumps(tool)
+        tool_defs = []
+        for source_key in ("tools", "functions"):
+            tool_list = inv_params.get(source_key, [])
+            if isinstance(tool_list, list):
+                tool_defs.extend(tool_list)
+        if tool_defs:
+            yield GEN_AI_TOOL_DEFINITIONS_KEY, safe_json_dumps(tool_defs)
 
 
 @stop_on_exception
@@ -363,15 +388,10 @@ def token_counts(outputs: Mapping[str, Any] | None) -> Iterator[tuple[str, int]]
     ]:
         if (token_count := get_first_value(token_usage, keys)) is not None:
             yield attribute_name, token_count
-    # OpenAI completion_tokens_details
-    if (details := token_usage.get("completion_tokens_details")) is not None:
-        if (token_count := get_first_value(details, ("reasoning_tokens",))) is not None:
-            yield GEN_AI_RESPONSE_FINISH_REASONS_KEY, token_count
     # langchain_core UsageMetadata
     for attribute_name, details_key, keys in [  # type: ignore[assignment]
         (GEN_AI_USAGE_INPUT_TOKENS_KEY, None, ("input_tokens",)),
         (GEN_AI_USAGE_OUTPUT_TOKENS_KEY, None, ("output_tokens",)),
-        (GEN_AI_RESPONSE_FINISH_REASONS_KEY, "output_token_details", ("reasoning",)),
     ]:
         details = token_usage.get(details_key) if details_key else token_usage
         if details is not None:
@@ -403,7 +423,6 @@ def function_calls(outputs: Mapping[str, Any] | None) -> Iterator[tuple[str, str
         return
     if not isinstance(fc, dict):
         return
-    yield GEN_AI_OPERATION_NAME_KEY, EXECUTE_TOOL_OPERATION_NAME
     yield GEN_AI_TOOL_TYPE_KEY, "function"
     name = fc.get("name")
     if isinstance(name, str):
@@ -414,19 +433,20 @@ def function_calls(outputs: Mapping[str, Any] | None) -> Iterator[tuple[str, str
     call_id = fc.get("id")
     if isinstance(call_id, str):
         yield GEN_AI_TOOL_CALL_ID_KEY, call_id
-    args = fc.get("arguments")
-    if args is not None:
-        if isinstance(args, str):
-            try:
-                args_json = safe_json_dumps(json.loads(args))
-            except Exception:
+    if _should_capture_content_on_spans():
+        args = fc.get("arguments")
+        if args is not None:
+            if isinstance(args, str):
+                try:
+                    args_json = safe_json_dumps(json.loads(args))
+                except Exception:
+                    args_json = safe_json_dumps(args)
+            else:
                 args_json = safe_json_dumps(args)
-        else:
-            args_json = safe_json_dumps(args)
-        yield GEN_AI_TOOL_ARGS_KEY, args_json
-    result = fc.get("result")
-    if result is not None:
-        yield GEN_AI_TOOL_CALL_RESULT_KEY, safe_json_dumps(result)
+            yield GEN_AI_TOOL_ARGS_KEY, args_json
+        result = fc.get("result")
+        if result is not None:
+            yield GEN_AI_TOOL_CALL_RESULT_KEY, safe_json_dumps(result)
 
 
 @stop_on_exception
@@ -437,7 +457,7 @@ def tools(run: Run) -> Iterator[tuple[str, str]]:
         return
     if not isinstance(serialized, Mapping):
         return
-    yield GEN_AI_TOOL_TYPE_KEY, "extension"
+    yield GEN_AI_TOOL_TYPE_KEY, "function"
     if name := serialized.get("name"):
         yield GEN_AI_TOOL_NAME_KEY, name
     if description := serialized.get("description"):
@@ -445,23 +465,24 @@ def tools(run: Run) -> Iterator[tuple[str, str]]:
     if run.extra and hasattr(run.extra, "get"):
         if tool_call_id := run.extra.get("tool_call_id"):
             yield GEN_AI_TOOL_CALL_ID_KEY, tool_call_id
-    if run.inputs and hasattr(run.inputs, "get"):
-        if input_val := run.inputs.get("input"):
-            if isinstance(input_val, str):
-                yield GEN_AI_TOOL_ARGS_KEY, input_val
-            else:
-                yield GEN_AI_TOOL_ARGS_KEY, safe_json_dumps(input_val)
-    if run.outputs and hasattr(run.outputs, "get"):
-        if result := run.outputs.get("output"):
-            if isinstance(result, BaseMessage):
-                result_content: str = str(result.content) if hasattr(result, "content") else str(result)
-            elif hasattr(result, "content"):
-                result_content = str(result.content)
-            elif isinstance(result, str):
-                result_content = result
-            else:
-                result_content = safe_json_dumps(result)
-            yield GEN_AI_TOOL_CALL_RESULT_KEY, result_content
+    if _should_capture_content_on_spans():
+        if run.inputs and hasattr(run.inputs, "get"):
+            if input_val := run.inputs.get("input"):
+                if isinstance(input_val, str):
+                    yield GEN_AI_TOOL_ARGS_KEY, input_val
+                else:
+                    yield GEN_AI_TOOL_ARGS_KEY, safe_json_dumps(input_val)
+        if run.outputs and hasattr(run.outputs, "get"):
+            if result := run.outputs.get("output"):
+                if isinstance(result, BaseMessage):
+                    result_content: str = str(result.content) if hasattr(result, "content") else str(result)
+                elif hasattr(result, "content"):
+                    result_content = str(result.content)
+                elif isinstance(result, str):
+                    result_content = result
+                else:
+                    result_content = safe_json_dumps(result)
+                yield GEN_AI_TOOL_CALL_RESULT_KEY, result_content
 
 
 def chain_node_messages(
@@ -472,6 +493,8 @@ def chain_node_messages(
 
     Chain nodes typically store messages as ``{"messages": [BaseMessage, ...]}``.
     """
+    if not _should_capture_content_on_spans():
+        return
     if not data or not isinstance(data, Mapping):
         return
     messages = data.get("messages")
@@ -512,6 +535,42 @@ def build_llm_invocation(run: Run) -> LLMInvocation:
     for _, val in llm_provider(run.extra):
         inv.provider = val
         break
+
+    # --- Request parameters from invocation_params ---
+    if run.extra and isinstance(run.extra, Mapping):
+        inv_params = run.extra.get("invocation_params") or {}
+        if isinstance(inv_params, Mapping):
+            if (temp := inv_params.get("temperature")) is not None:
+                inv.temperature = float(temp)
+            if (tp := inv_params.get("top_p")) is not None:
+                inv.top_p = float(tp)
+            if (mt := inv_params.get("max_tokens")) is not None:
+                inv.max_tokens = int(mt)
+            if (fp := inv_params.get("frequency_penalty")) is not None:
+                inv.frequency_penalty = float(fp)
+            if (pp := inv_params.get("presence_penalty")) is not None:
+                inv.presence_penalty = float(pp)
+            if (seed_val := inv_params.get("seed")) is not None:
+                inv.seed = int(seed_val)
+            stop = inv_params.get("stop")
+            if stop is not None:
+                if isinstance(stop, str):
+                    inv.stop_sequences = [stop]
+                elif isinstance(stop, list):
+                    inv.stop_sequences = [str(s) for s in stop]
+            for key in ("base_url", "api_base", "azure_endpoint"):
+                if addr := inv_params.get(key):
+                    inv.server_address = str(addr).rstrip("/")
+                    break
+
+    # --- Response model name (from llm_output) ---
+    if run.outputs and isinstance(run.outputs, Mapping):
+        llm_output = run.outputs.get("llm_output")
+        if llm_output and hasattr(llm_output, "get"):
+            for key in ("model_name", "model"):
+                if resp_model := llm_output.get(key):
+                    inv.response_model_name = str(resp_model)
+                    break
 
     # --- Token counts ---
     for key, val in token_counts(run.outputs):

--- a/tests/langchain/test_utils.py
+++ b/tests/langchain/test_utils.py
@@ -5,7 +5,7 @@ import datetime
 import json
 from enum import Enum
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from microsoft.genai._langchain._utils import (
     DictWithLock,
@@ -20,10 +20,12 @@ from microsoft.genai._langchain._utils import (
     GEN_AI_OUTPUT_MESSAGES_KEY,
     GEN_AI_PROVIDER_NAME_KEY,
     GEN_AI_REQUEST_MODEL_KEY,
+    GEN_AI_RESPONSE_FINISH_REASONS_KEY,
     GEN_AI_SYSTEM_INSTRUCTIONS_KEY,
     GEN_AI_TOOL_ARGS_KEY,
     GEN_AI_TOOL_CALL_ID_KEY,
     GEN_AI_TOOL_CALL_RESULT_KEY,
+    GEN_AI_TOOL_DEFINITIONS_KEY,
     GEN_AI_TOOL_DESCRIPTION_KEY,
     GEN_AI_TOOL_NAME_KEY,
     GEN_AI_TOOL_TYPE_KEY,
@@ -313,6 +315,22 @@ class TestTokenCounts(TestCase):
         self.assertEqual(result[GEN_AI_USAGE_INPUT_TOKENS_KEY], 10)
         self.assertEqual(result[GEN_AI_USAGE_OUTPUT_TOKENS_KEY], 20)
 
+    def test_ignores_reasoning_token_metadata(self):
+        outputs = {
+            "llm_output": {
+                "token_usage": {
+                    "completion_tokens_details": {"reasoning_tokens": 7},
+                    "input_tokens": 10,
+                    "output_token_details": {"reasoning": 5},
+                    "output_tokens": 20,
+                }
+            }
+        }
+        result = dict(token_counts(outputs))
+        self.assertEqual(result[GEN_AI_USAGE_INPUT_TOKENS_KEY], 10)
+        self.assertEqual(result[GEN_AI_USAGE_OUTPUT_TOKENS_KEY], 20)
+        self.assertNotIn(GEN_AI_RESPONSE_FINISH_REASONS_KEY, result)
+
     def test_returns_empty_on_none(self):
         self.assertEqual(list(token_counts(None)), [])
 
@@ -323,9 +341,18 @@ class TestInvocationParameters(TestCase):
             run_type="llm",
             extra={"invocation_params": {"tools": [{"name": "get_weather"}]}},
         )
-        result = list(invocation_parameters(run))
+        result = dict(invocation_parameters(run))
         self.assertEqual(len(result), 1)
-        self.assertIn("get_weather", result[0][1])
+        self.assertIn("get_weather", result[GEN_AI_TOOL_DEFINITIONS_KEY])
+
+    def test_extracts_tools_for_chat_model(self):
+        run = _make_run(
+            run_type="chat_model",
+            extra={"invocation_params": {"functions": [{"name": "get_weather"}]}},
+        )
+        result = dict(invocation_parameters(run))
+        self.assertEqual(len(result), 1)
+        self.assertIn("get_weather", result[GEN_AI_TOOL_DEFINITIONS_KEY])
 
     def test_skips_non_llm(self):
         run = _make_run(run_type="chain", extra={"invocation_params": {"tools": []}})
@@ -355,6 +382,33 @@ class TestFunctionCalls(TestCase):
         result = dict(function_calls(outputs))
         self.assertEqual(result[GEN_AI_TOOL_NAME_KEY], "get_weather")
         self.assertEqual(result[GEN_AI_TOOL_TYPE_KEY], "function")
+        self.assertNotIn(GEN_AI_OPERATION_NAME_KEY, result)
+        self.assertNotIn(GEN_AI_TOOL_ARGS_KEY, result)
+
+    @patch("microsoft.genai._langchain._utils._should_capture_content_on_spans", return_value=True)
+    def test_extracts_function_call_content_when_enabled(self, _mock_capture):
+        outputs = {
+            "generations": [
+                [
+                    {
+                        "message": {
+                            "kwargs": {
+                                "additional_kwargs": {
+                                    "function_call": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "NYC"}',
+                                        "result": {"temperature": "72F"},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            ]
+        }
+        result = dict(function_calls(outputs))
+        self.assertEqual(result[GEN_AI_TOOL_ARGS_KEY], '{"city":"NYC"}')
+        self.assertEqual(result[GEN_AI_TOOL_CALL_RESULT_KEY], '{"temperature":"72F"}')
 
     def test_returns_empty_on_none(self):
         self.assertEqual(list(function_calls(None)), [])
@@ -372,10 +426,24 @@ class TestTools(TestCase):
         result = dict(tools(run))
         self.assertEqual(result[GEN_AI_TOOL_NAME_KEY], "calculator")
         self.assertEqual(result[GEN_AI_TOOL_DESCRIPTION_KEY], "Does math")
-        self.assertEqual(result[GEN_AI_TOOL_TYPE_KEY], "extension")
+        self.assertEqual(result[GEN_AI_TOOL_TYPE_KEY], "function")
+        self.assertNotIn(GEN_AI_TOOL_ARGS_KEY, result)
+        self.assertNotIn(GEN_AI_TOOL_CALL_RESULT_KEY, result)
+        self.assertEqual(result[GEN_AI_TOOL_CALL_ID_KEY], "tc-1")
+
+    @patch("microsoft.genai._langchain._utils._should_capture_content_on_spans", return_value=True)
+    def test_extracts_tool_payloads_when_content_capture_enabled(self, _mock_capture):
+        run = _make_run(
+            run_type="tool",
+            serialized={"name": "calculator", "description": "Does math"},
+            inputs={"input": "2+2"},
+            outputs={"output": "4"},
+            extra={"tool_call_id": "tc-1"},
+        )
+        result = dict(tools(run))
+        self.assertEqual(result[GEN_AI_TOOL_TYPE_KEY], "function")
         self.assertEqual(result[GEN_AI_TOOL_ARGS_KEY], "2+2")
         self.assertEqual(result[GEN_AI_TOOL_CALL_RESULT_KEY], "4")
-        self.assertEqual(result[GEN_AI_TOOL_CALL_ID_KEY], "tc-1")
 
     def test_skips_non_tool(self):
         run = _make_run(run_type="llm", serialized={"name": "calc"})
@@ -383,7 +451,12 @@ class TestTools(TestCase):
 
 
 class TestChainNodeMessages(TestCase):
-    def test_extracts_messages_from_dict(self):
+    def test_skips_messages_when_content_capture_disabled(self):
+        data = {"messages": [{"content": "Hello", "role": "human"}]}
+        self.assertEqual(list(chain_node_messages(data, GEN_AI_INPUT_MESSAGES_KEY)), [])
+
+    @patch("microsoft.genai._langchain._utils._should_capture_content_on_spans", return_value=True)
+    def test_extracts_messages_from_dict(self, _mock_capture):
         data = {"messages": [{"content": "Hello", "role": "human"}]}
         result = list(chain_node_messages(data, GEN_AI_INPUT_MESSAGES_KEY))
         self.assertEqual(len(result), 1)
@@ -536,3 +609,33 @@ class TestBuildLlmInvocation(TestCase):
         inv = build_llm_invocation(run)
         self.assertEqual(inv.operation_name, CHAT_OPERATION_NAME)
         self.assertIsNone(inv.request_model)
+
+    def test_builds_invocation_with_request_parameters(self):
+        run = _make_run(
+            run_type="llm",
+            outputs={"llm_output": {"model_name": "gpt-4o", "id": "resp-1"}},
+            extra={
+                "invocation_params": {
+                    "temperature": "0.5",
+                    "top_p": "0.9",
+                    "max_tokens": "256",
+                    "frequency_penalty": "0.1",
+                    "presence_penalty": "0.2",
+                    "seed": "7",
+                    "stop": ["END"],
+                    "base_url": "https://example.test/",
+                }
+            },
+            inputs=None,
+        )
+        inv = build_llm_invocation(run)
+        self.assertEqual(inv.temperature, 0.5)
+        self.assertEqual(inv.top_p, 0.9)
+        self.assertEqual(inv.max_tokens, 256)
+        self.assertEqual(inv.frequency_penalty, 0.1)
+        self.assertEqual(inv.presence_penalty, 0.2)
+        self.assertEqual(inv.seed, 7)
+        self.assertEqual(inv.stop_sequences, ["END"])
+        self.assertEqual(inv.server_address, "https://example.test")
+        self.assertEqual(inv.response_model_name, "gpt-4o")
+        self.assertEqual(inv.response_id, "resp-1")


### PR DESCRIPTION
## Summary

Brings the LangChain tracer into feature parity with `langchain-azure-ai` and the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/main/model/gen-ai).

## Changes

### SpanKind (Critical)
- LLM inference spans now use `SpanKind.CLIENT` (was `INTERNAL`)
- Tool and agent wrapper spans remain `SpanKind.INTERNAL`

### LLM Request Parameters (High)
- Extract `temperature`, `top_p`, `max_tokens`, `frequency_penalty`, `presence_penalty`, `seed`, `stop_sequences` from `invocation_params`
- Extract `server.address` from invocation params
- Extract `gen_ai.response.model` from LLM output

### Content Capture Opt-in (Critical — privacy)
- All message content, tool args/results now gated behind `OTEL_SEMCONV_STABILITY_OPT_IN` + `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`
- Agent spans, chain node messages, and tool spans all respect the same gate as LLM spans

### Agent Spans
- Aggregate `gen_ai.provider.name` from child LLM runs (required by semconv)
- Aggregate `gen_ai.usage.input_tokens` / `output_tokens` from child LLMs
- Support `gen_ai.agent.version` from instrumentor config
- LangGraph compatibility: `try/except TypeError` around `add_handler()`

### Bug Fixes
- `gen_ai.tool.type`: changed from hardcoded `"extension"` to `"function"` for LangChain tools
- `function_calls()`: no longer overwrites `gen_ai.operation.name` from `"chat"` to `"execute_tool"` on LLM spans
- `invocation_parameters()`: now handles `chat_model` run type (not just `llm`)
- Tool definitions: use `gen_ai.tool.definitions` key (was incorrectly using `gen_ai.tool.call.arguments.{idx}`)
- `token_counts()`: no longer maps reasoning tokens to `gen_ai.response.finish_reasons`
- Span name: `"chat"` instead of `"chat None"` when model is unknown

### Tests & Validation
- All 127 langchain tests pass (430 total excl. pre-existing a365 failure)
- Added e2e validation sample (`samples/validate_traces.py`)

## Semconv Coverage After This PR

| Span Type | Required Attrs | Recommended | Opt-in |
|-----------|---------------|-------------|--------|
| LLM (chat) | ✅ operation.name, provider.name | ✅ request params, tokens, finish_reasons, response.model | ✅ messages, system_instructions (gated) |
| invoke_agent | ✅ operation.name, provider.name | ✅ agent.name/id/desc/version, tokens, server.* | ✅ messages (gated) |
| execute_tool | ✅ operation.name, tool.name | ✅ tool.type, description, call.id | ✅ args/result (gated) |
