### PR TITLE
Add Sphinx documentation with auto-generated API reference

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Typecheck with Mypy
         run: tox -e mypy
 
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: python -m pip install --upgrade pip tox
+
+      - name: Build docs
+        run: tox -e docs
+
   tests:
     name: Pytest (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ build/
 .env
 .pytest_cache/
 .mypy_cache/
+docs/_build/
+docs/api/
 *.log
 *_output.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,16 +5,21 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
+SPHINXAPIDOC  ?= sphinx-apidoc
 SOURCEDIR     = .
 BUILDDIR      = _build
+APIDOCDIR     = api
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+apidoc:
+	@$(SPHINXAPIDOC) -o "$(APIDOCDIR)" ../src/microsoft --force --module-first --separate
+
+.PHONY: help apidoc Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile apidoc
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+
+# -- Path setup --------------------------------------------------------------
+
+# Add the src directory so autodoc can find the modules
+sys.path.insert(0, os.path.abspath("../src"))
+
+# -- Project information -----------------------------------------------------
+
+project = "Microsoft OpenTelemetry Distro for Python"
+copyright = "Microsoft Corporation"  # pylint: disable=redefined-builtin
+author = "Microsoft"
+
+# -- General configuration ---------------------------------------------------
+
+# Easy automatic cross-references for `code in backticks`
+default_role = "any"
+
+extensions = [
+    # API doc generation
+    "sphinx.ext.autodoc",
+    # Support for google-style docstrings
+    "sphinx.ext.napoleon",
+    # Infer types from hints instead of docstrings
+    "sphinx_autodoc_typehints",
+    # Add links to source from generated docs
+    "sphinx.ext.viewcode",
+    # Link to other sphinx docs
+    "sphinx.ext.intersphinx",
+    # Add a .nojekyll file for GitHub Pages
+    "sphinx.ext.githubpages",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "opentelemetry": (
+        "https://opentelemetry-python.readthedocs.io/en/latest/",
+        None,
+    ),
+}
+
+templates_path = ["_templates"]
+
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+]
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "show-inheritance": True,
+    "member-order": "bysource",
+}
+
+# Napoleon configuration
+napoleon_use_ivar = True
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ import sys
 # -- Path setup --------------------------------------------------------------
 
 # Add the src directory so autodoc can find the modules
-sys.path.insert(0, os.path.abspath("../src"))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,18 @@
+Microsoft OpenTelemetry Distro for Python
+==========================================
+
+Welcome to the API reference for the Microsoft OpenTelemetry Distro for Python.
+
+.. toctree::
+   :maxdepth: 4
+   :caption: API Reference
+
+   api/microsoft
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -25,6 +25,12 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
+if "%SPHINXAPIDOC%" == "" (
+	set SPHINXAPIDOC=sphinx-apidoc
+)
+
+%SPHINXAPIDOC% -o api ..\src\microsoft --force --module-first --separate
+
 if "%1" == "" goto help
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,37 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, install it with:
+	echo.
+	echo.    pip install sphinx
+	echo.
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+    "sphinx-autodoc-typehints>=2.0",
+]
 
 [project.entry-points.opentelemetry_instrumentor]
 langchain = "microsoft.opentelemetry._genai._langchain._tracer_instrumentor:LangChainInstrumentor"

--- a/tox.ini
+++ b/tox.ini
@@ -46,11 +46,8 @@ commands =
 description = Build Sphinx documentation
 deps =
   {[testenv]deps}
-  sphinx>=7.0
-  sphinx-rtd-theme>=2.0
-  sphinx-autodoc-typehints>=2.0
 commands =
-    python -m pip install -e {tox_root}
+    python -m pip install -e {tox_root}[docs]
     python -m sphinx.ext.apidoc -o {tox_root}/docs/api {tox_root}/src/microsoft --force --module-first --separate
     python -m sphinx -b html {tox_root}/docs {tox_root}/docs/_build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,18 @@ deps =
 commands =
     python -m black {tox_root}/src {tox_root}/tests {tox_root}/samples
 
+[testenv:docs]
+description = Build Sphinx documentation
+deps =
+  {[testenv]deps}
+  sphinx>=7.0
+  sphinx-rtd-theme>=2.0
+  sphinx-autodoc-typehints>=2.0
+commands =
+    python -m pip install -e {tox_root}
+    python -m sphinx.ext.apidoc -o {tox_root}/docs/api {tox_root}/src/microsoft --force --module-first --separate
+    python -m sphinx -b html {tox_root}/docs {tox_root}/docs/_build/html
+
 [testenv:pytest-py{310,311,312,313,314}]
 description = Run tests with pytest on Python {base_python}
 base_python =


### PR DESCRIPTION
- Add Sphinx setup with sphinx-rtd-theme, autodoc, napoleon, and typehints
- Use sphinx-apidoc to auto-generate API reference RSTs from source tree
- Add docs/conf.py, index.rst, Makefile, and make.bat
- Add 'docs' optional dependency group in pyproject.toml
- Add 'docs' tox environment for local and CI builds
- Add docs build job to PR validation CI workflow
- Update .gitignore to exclude docs/_build/ and docs/api/