### PR TITLE
feat: add console exporter for traces, metrics, and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ use_microsoft_opentelemetry(
 | `a365_cluster_category` | `str` | `"prod"` | Cluster category for endpoint discovery. Falls back to `A365_CLUSTER_CATEGORY` env var. |
 | `a365_use_s2s_endpoint` | `bool` | `False` | Use the S2S endpoint. Falls back to `A365_USE_S2S_ENDPOINT` env var. |
 | `a365_suppress_invoke_agent_input` | `bool` | `False` | Strip input messages from InvokeAgent spans. Falls back to `A365_SUPPRESS_INVOKE_AGENT_INPUT` env var. |
+| `enable_console` | `bool` | `False` | Enable console exporter for traces, metrics, and logs (development only). Auto-enables when no other exporter is active. Mirrors `ExportTarget.Console` from the .NET distro. |
 
 A365 also reads additional environment variables defined in `a365/constants.py` (e.g. `ENABLE_A365_OBSERVABILITY_EXPORTER`, `A365_OBSERVABILITY_DOMAIN_OVERRIDE`, FIC auth vars). Kwargs take precedence when provided.
 
@@ -110,6 +111,21 @@ export ENABLE_OBSERVABILITY=true
 export ENABLE_A365_OBSERVABILITY_EXPORTER=true
 export A365_TENANT_ID=my-tenant-id
 export A365_AGENT_ID=my-agent-id
+```
+
+### Console Exporter (Development)
+
+The console exporter writes traces, metrics, and logs to stdout for local development and debugging. This mirrors the `ExportTarget.Console` behaviour from the [.NET distro](https://github.com/microsoft/opentelemetry-distro-dotnet).
+
+Console export **auto-enables when no other exporter is active** (Azure Monitor off, OTLP off, A365 off). You can also enable it explicitly alongside other exporters.
+
+**Example:**
+
+```python
+use_microsoft_opentelemetry(
+    enable_console=True,
+    enable_azure_monitor=False,
+)
 ```
 
 ## Planned Scope

--- a/samples/langchain/validate_traces.py
+++ b/samples/langchain/validate_traces.py
@@ -33,7 +33,7 @@ class MemoryExporter(SpanExporter):
         pass
 
 
-def main(): # pylint: disable=too-many-statements
+def main():  # pylint: disable=too-many-statements
     # Enable content capture for validation (must be set before instrumentation)
     os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
     os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "SPAN_ONLY"
@@ -67,10 +67,16 @@ def main(): # pylint: disable=too-many-statements
     from langchain_core.output_parsers import StrOutputParser
 
     llm2 = FakeListLLM(responses=["42 is the answer."])
-    chain = ChatPromptTemplate.from_messages([
-        ("system", "You are helpful."),
-        ("human", "{q}"),
-    ]) | llm2 | StrOutputParser()
+    chain = (
+        ChatPromptTemplate.from_messages(
+            [
+                ("system", "You are helpful."),
+                ("human", "{q}"),
+            ]
+        )
+        | llm2
+        | StrOutputParser()
+    )
     chain.invoke({"q": "What is 6*7?"})
 
     # ── Sample 3: Tool invocation ───────────────────────────────────────
@@ -110,12 +116,9 @@ def main(): # pylint: disable=too-many-statements
         check("gen_ai.operation.name present", "gen_ai.operation.name" in attrs)
         check("gen_ai.operation.name == 'chat'", attrs.get("gen_ai.operation.name") == "chat")
         check("gen_ai.provider.name present", "gen_ai.provider.name" in attrs)
-        check("SpanKind is CLIENT", span.kind == SpanKind.CLIENT,
-              f"actual: {span.kind.name}")
-        check("Span name is not 'chat None'", "None" not in span.name,
-              f"actual: '{span.name}'")
-        check("gen_ai.response.finish_reasons present",
-              "gen_ai.response.finish_reasons" in attrs)
+        check("SpanKind is CLIENT", span.kind == SpanKind.CLIENT, f"actual: {span.kind.name}")
+        check("Span name is not 'chat None'", "None" not in span.name, f"actual: '{span.name}'")
+        check("gen_ai.response.finish_reasons present", "gen_ai.response.finish_reasons" in attrs)
 
     # ── Tool span checks ───────────────────────────────────────────────
     print(f"\n{'='*60}")
@@ -126,22 +129,19 @@ def main(): # pylint: disable=too-many-statements
         attrs = span.attributes
         print(f"\n  Span: {span.name}")
         check("gen_ai.operation.name present", "gen_ai.operation.name" in attrs)
-        check("gen_ai.operation.name == 'execute_tool'",
-              attrs.get("gen_ai.operation.name") == "execute_tool")
+        check("gen_ai.operation.name == 'execute_tool'", attrs.get("gen_ai.operation.name") == "execute_tool")
         check("gen_ai.tool.name present", "gen_ai.tool.name" in attrs)
-        check("gen_ai.tool.type == 'function'",
-              attrs.get("gen_ai.tool.type") == "function",
-              f"actual: {attrs.get('gen_ai.tool.type')}")
+        check(
+            "gen_ai.tool.type == 'function'",
+            attrs.get("gen_ai.tool.type") == "function",
+            f"actual: {attrs.get('gen_ai.tool.type')}",
+        )
         check("gen_ai.tool.description present", "gen_ai.tool.description" in attrs)
-        check("SpanKind is INTERNAL", span.kind == SpanKind.INTERNAL,
-              f"actual: {span.kind.name}")
-        check("Span name format 'execute_tool <name>'",
-              span.name.startswith("execute_tool "))
+        check("SpanKind is INTERNAL", span.kind == SpanKind.INTERNAL, f"actual: {span.kind.name}")
+        check("Span name format 'execute_tool <name>'", span.name.startswith("execute_tool "))
         # Content capture enabled — args/results should be present
-        check("gen_ai.tool.call.arguments present (content on)",
-              "gen_ai.tool.call.arguments" in attrs)
-        check("gen_ai.tool.call.result present (content on)",
-              "gen_ai.tool.call.result" in attrs)
+        check("gen_ai.tool.call.arguments present (content on)", "gen_ai.tool.call.arguments" in attrs)
+        check("gen_ai.tool.call.result present (content on)", "gen_ai.tool.call.result" in attrs)
 
     # ── All-span attribute dump ─────────────────────────────────────────
     print(f"\n{'='*60}")

--- a/src/microsoft/opentelemetry/_console/__init__.py
+++ b/src/microsoft/opentelemetry/_console/__init__.py
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+from microsoft.opentelemetry._console.handler import (
+    create_console_components,
+    ConsoleHandlers,
+)
+
+__all__ = [
+    "create_console_components",
+    "ConsoleHandlers",
+]

--- a/src/microsoft/opentelemetry/_console/handler.py
+++ b/src/microsoft/opentelemetry/_console/handler.py
@@ -1,0 +1,54 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+from dataclasses import dataclass, field
+from logging import getLogger
+from typing import Optional
+
+from opentelemetry.sdk.trace.export import SpanProcessor
+from opentelemetry.sdk.metrics.export import MetricReader
+from opentelemetry.sdk._logs import LogRecordProcessor
+
+_logger = getLogger(__name__)
+
+
+@dataclass
+class ConsoleHandlers:
+    span_processor: Optional[SpanProcessor] = field(default=None)
+    metric_reader: Optional[MetricReader] = field(default=None)
+    log_record_processor: Optional[LogRecordProcessor] = field(default=None)
+
+
+def create_console_components(
+    enable_traces: bool = True,
+    enable_metrics: bool = True,
+    enable_logs: bool = True,
+) -> ConsoleHandlers:
+    """Creates console exporters for the requested signals.
+
+    Console exporters write telemetry to stdout for local development
+    and debugging.  This mirrors the ``ExportTarget.Console`` behaviour
+    of the .NET distro.
+
+    No additional configuration is required -- the exporters use their
+    default settings.
+    """
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+    from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, PeriodicExportingMetricReader
+    from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor, ConsoleLogExporter
+
+    components = ConsoleHandlers()
+
+    if enable_traces:
+        components.span_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+
+    if enable_metrics:
+        components.metric_reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
+
+    if enable_logs:
+        components.log_record_processor = SimpleLogRecordProcessor(ConsoleLogExporter())
+
+    return components

--- a/src/microsoft/opentelemetry/_constants.py
+++ b/src/microsoft/opentelemetry/_constants.py
@@ -42,6 +42,10 @@ _SUPPORTED_INSTRUMENTED_LIBRARIES = (
     "openai_agents",
 )
 
+# --- Console Exporter Constants ---
+
+ENABLE_CONSOLE_ARG = "enable_console"
+
 # --- Microsoft Distro Constants ---
 
 ENABLE_AZURE_MONITOR_ARG = "enable_azure_monitor"

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -36,6 +36,7 @@ from microsoft.opentelemetry._constants import (
     A365_USE_S2S_ENDPOINT_ARG,
     A365_SUPPRESS_INVOKE_AGENT_INPUT_ARG,
     ENABLE_AZURE_MONITOR_ARG,
+    ENABLE_CONSOLE_ARG,
     INSTRUMENTATION_OPTIONS_ARG,
     LOGGER_NAME_ARG,
     LOGGING_FORMATTER_ARG,
@@ -48,8 +49,10 @@ from microsoft.opentelemetry._constants import (
     _SUPPORTED_INSTRUMENTED_LIBRARIES,
 )
 from microsoft.opentelemetry._instrumentation import get_dist_dependency_conflicts
+from microsoft.opentelemetry._otlp import is_otlp_enabled
 from microsoft.opentelemetry._utils import (
     _append_azure_monitor_components,
+    _append_console_components,
     _append_otlp_components,
 )
 
@@ -120,10 +123,16 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:
     :keyword bool a365_suppress_invoke_agent_input:
         Strip input messages from InvokeAgent spans before export. Also read from
         ``A365_SUPPRESS_INVOKE_AGENT_INPUT`` env var. Defaults to False.
+    :keyword bool enable_console:
+        Enable console exporter for traces, metrics, and logs (development
+        only).  Mirrors ``ExportTarget.Console`` from the .NET distro.
+        Auto-enables when no other exporter is active (Azure Monitor off,
+        OTLP off, A365 off).  Defaults to False.
     :rtype: None
     """
 
     enable_azure_monitor = kwargs.pop(ENABLE_AZURE_MONITOR_ARG, True)
+    enable_console: bool = bool(kwargs.pop(ENABLE_CONSOLE_ARG, False))
     enable_a365: bool = bool(kwargs.pop(ENABLE_A365_ARG, False))
     a365_token_resolver = kwargs.pop(A365_TOKEN_RESOLVER_ARG, None)
     a365_tenant_id = kwargs.pop(A365_TENANT_ID_ARG, None)
@@ -152,6 +161,12 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:
         use_s2s_endpoint=a365_use_s2s_endpoint,
         suppress_invoke_agent_input=a365_suppress_invoke_agent_input,
     )
+
+    # ---- Console exporters (dev-only, mirrors ExportTarget.Console) ----
+    # Auto-enable when no other exporter destination is active.
+    if not enable_console and not enable_azure_monitor and not enable_a365 and not is_otlp_enabled():
+        enable_console = True
+    _append_console_components(otel_kwargs, enable_console)
 
     # ---- Build and register providers ----
     tracer_provider: Optional[TracerProvider] = None

--- a/src/microsoft/opentelemetry/_utils.py
+++ b/src/microsoft/opentelemetry/_utils.py
@@ -17,6 +17,7 @@ from microsoft.opentelemetry._constants import (
     SPAN_PROCESSORS_ARG,
 )
 from microsoft.opentelemetry._otlp import is_otlp_enabled, create_otlp_components
+from microsoft.opentelemetry._console import create_console_components
 
 _logger = getLogger(__name__)
 
@@ -49,6 +50,41 @@ def _append_otlp_components(otel_kwargs: Dict[str, Any]) -> None:
     if otlp.metric_reader:
         otel_kwargs[METRIC_READERS_ARG] = list(otel_kwargs.get(METRIC_READERS_ARG) or [])
         otel_kwargs[METRIC_READERS_ARG].append(otlp.metric_reader)
+
+
+# ---------------------------------------------------------------------------
+# Console helper functions
+# ---------------------------------------------------------------------------
+
+
+def _append_console_components(otel_kwargs: Dict[str, Any], enable_console: bool) -> None:
+    """Append console exporters to otel_kwargs when console export is enabled.
+
+    Console export is enabled when ``enable_console=True`` is passed as a
+    kwarg or auto-enabled by the distro when no other exporter is active.
+    This mirrors the ``ExportTarget.Console`` flag from the .NET distro
+    and is intended for local development and debugging.
+
+    Respects per-signal disable flags so that disabled pipelines do not
+    get unnecessary exporters.
+    """
+    if not enable_console:
+        return
+
+    console = create_console_components(
+        enable_traces=not otel_kwargs.get(DISABLE_TRACING_ARG, False),
+        enable_metrics=not otel_kwargs.get(DISABLE_METRICS_ARG, False),
+        enable_logs=not otel_kwargs.get(DISABLE_LOGGING_ARG, False),
+    )
+    if console.span_processor:
+        otel_kwargs[SPAN_PROCESSORS_ARG] = list(otel_kwargs.get(SPAN_PROCESSORS_ARG) or [])
+        otel_kwargs[SPAN_PROCESSORS_ARG].append(console.span_processor)
+    if console.log_record_processor:
+        otel_kwargs[LOG_RECORD_PROCESSORS_ARG] = list(otel_kwargs.get(LOG_RECORD_PROCESSORS_ARG) or [])
+        otel_kwargs[LOG_RECORD_PROCESSORS_ARG].append(console.log_record_processor)
+    if console.metric_reader:
+        otel_kwargs[METRIC_READERS_ARG] = list(otel_kwargs.get(METRIC_READERS_ARG) or [])
+        otel_kwargs[METRIC_READERS_ARG].append(console.metric_reader)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,165 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Tests for the console exporter handler module.
+
+Validates:
+  1. ``create_console_components()`` returns the expected processor/reader types.
+  2. Console components are wired into the distro's provider setup functions.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from microsoft.opentelemetry._console.handler import (
+    ConsoleHandlers,
+    create_console_components,
+)
+
+
+class TestCreateConsoleComponents(unittest.TestCase):
+    """Tests for create_console_components()."""
+
+    def test_all_signals_enabled(self):
+        components = create_console_components(enable_traces=True, enable_metrics=True, enable_logs=True)
+        self.assertIsInstance(components, ConsoleHandlers)
+        self.assertIsNotNone(components.span_processor)
+        self.assertIsNotNone(components.metric_reader)
+        self.assertIsNotNone(components.log_record_processor)
+
+    def test_traces_only(self):
+        components = create_console_components(enable_traces=True, enable_metrics=False, enable_logs=False)
+        self.assertIsNotNone(components.span_processor)
+        self.assertIsNone(components.metric_reader)
+        self.assertIsNone(components.log_record_processor)
+
+    def test_metrics_only(self):
+        components = create_console_components(enable_traces=False, enable_metrics=True, enable_logs=False)
+        self.assertIsNone(components.span_processor)
+        self.assertIsNotNone(components.metric_reader)
+        self.assertIsNone(components.log_record_processor)
+
+    def test_logs_only(self):
+        components = create_console_components(enable_traces=False, enable_metrics=False, enable_logs=True)
+        self.assertIsNone(components.span_processor)
+        self.assertIsNone(components.metric_reader)
+        self.assertIsNotNone(components.log_record_processor)
+
+    def test_all_disabled(self):
+        components = create_console_components(enable_traces=False, enable_metrics=False, enable_logs=False)
+        self.assertIsNone(components.span_processor)
+        self.assertIsNone(components.metric_reader)
+        self.assertIsNone(components.log_record_processor)
+
+    def test_span_processor_is_simple(self):
+        """Console uses SimpleSpanProcessor for immediate stdout output."""
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        components = create_console_components(enable_traces=True, enable_metrics=False, enable_logs=False)
+        self.assertIsInstance(components.span_processor, SimpleSpanProcessor)
+
+    def test_log_processor_is_simple(self):
+        """Console uses SimpleLogRecordProcessor for immediate stdout output."""
+        from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+
+        components = create_console_components(enable_traces=False, enable_metrics=False, enable_logs=True)
+        self.assertIsInstance(components.log_record_processor, SimpleLogRecordProcessor)
+
+
+class TestConsoleDistroIntegration(unittest.TestCase):
+    """Tests that console components are wired into use_microsoft_opentelemetry()."""
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._distro._append_azure_monitor_components", return_value=(None, None, None))
+    def test_console_not_enabled_when_azure_monitor_on(self, append_mock, otlp_utils_mock, otlp_distro_mock):
+        """Console export is NOT auto-enabled when Azure Monitor is active."""
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+
+        use_microsoft_opentelemetry(enable_azure_monitor=True)
+        otel_kwargs = append_mock.call_args[0][0]
+        span_processors = otel_kwargs.get("span_processors", [])
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        self.assertFalse(any(isinstance(sp, SimpleSpanProcessor) for sp in span_processors))
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=True)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=True)
+    @patch("microsoft.opentelemetry._utils.create_otlp_components")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_console_not_enabled_when_otlp_on(
+        self, tracing_mock, metrics_mock, logging_mock, otlp_create_mock, otlp_utils_mock, otlp_distro_mock
+    ):
+        """Console export is NOT auto-enabled when OTLP is active."""
+        from microsoft.opentelemetry._otlp.handler import OtlpHandlers
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        otlp_create_mock.return_value = OtlpHandlers()
+
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+
+        use_microsoft_opentelemetry(enable_azure_monitor=False)
+        call_kwargs = tracing_mock.call_args[0][1]
+        span_processors = call_kwargs.get("span_processors", [])
+        self.assertFalse(any(isinstance(sp, SimpleSpanProcessor) for sp in span_processors))
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_console_auto_enables_when_all_off(
+        self, tracing_mock, metrics_mock, logging_mock, otlp_utils_mock, otlp_distro_mock
+    ):
+        """Console auto-enables when Azure Monitor, OTLP, and A365 are all off."""
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        use_microsoft_opentelemetry(enable_azure_monitor=False, enable_a365=False)
+        call_kwargs = tracing_mock.call_args[0][1]
+        span_processors = call_kwargs.get("span_processors", [])
+        self.assertTrue(any(isinstance(sp, SimpleSpanProcessor) for sp in span_processors))
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._distro._append_azure_monitor_components", return_value=(None, None, None))
+    def test_console_enabled_via_kwarg(self, append_mock, otlp_utils_mock, otlp_distro_mock):
+        """enable_console=True adds console processors even with Azure Monitor on."""
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+
+        use_microsoft_opentelemetry(enable_console=True, enable_azure_monitor=True)
+        otel_kwargs = append_mock.call_args[0][0]
+        span_processors = otel_kwargs.get("span_processors", [])
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        self.assertTrue(any(isinstance(sp, SimpleSpanProcessor) for sp in span_processors))
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._distro._append_azure_monitor_components", return_value=(None, None, None))
+    def test_console_kwarg_not_forwarded(self, append_mock, otlp_utils_mock, otlp_distro_mock):
+        """enable_console is consumed, not forwarded to otel_kwargs."""
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+
+        use_microsoft_opentelemetry(enable_console=True)
+        otel_kwargs = append_mock.call_args[0][0]
+        self.assertNotIn("enable_console", otel_kwargs)
+
+    @patch("microsoft.opentelemetry._distro.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._utils.is_otlp_enabled", return_value=False)
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_console_respects_disable_tracing(
+        self, tracing_mock, metrics_mock, logging_mock, otlp_utils_mock, otlp_distro_mock
+    ):
+        """Console does not add span processor when tracing is disabled."""
+        from microsoft.opentelemetry._distro import use_microsoft_opentelemetry
+
+        use_microsoft_opentelemetry(enable_console=True, disable_tracing=True, enable_azure_monitor=False)
+        tracing_mock.assert_not_called()


### PR DESCRIPTION
Mirrors ExportTarget.Console from the .NET distro. Console exporters write telemetry to stdout for local development and debugging.

- Auto-enables when no other exporter is active (Azure Monitor, OTLP, A365 all off)
- Explicit opt-in via enable_console=True kwarg alongside other exporters
- Uses SimpleSpanProcessor/SimpleLogRecordProcessor for immediate output
- Respects disable_tracing, disable_metrics, disable_logging flags
- Adds _console handler module following the same pattern as _otlp
- Includes 14 unit and integration tests