### PR TITLE
Disable non-genai instrumentations by default when A365 exporter is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## Unreleased
+
+### Features Added
+
+- Disable web-framework / HTTP-client instrumentations
+  (`django`, `fastapi`, `flask`, `psycopg2`, `requests`, `urllib`, `urllib3`)
+  by default when A365 is enabled. GenAI instrumentations
+  (`langchain`, `openai`, `openai_agents`, `semantic_kernel`,
+  `agent_framework`) remain enabled. Users can override either default via
+  `instrumentation_options`.
+
 ## 0.1.0a4 (2026-04-24)
 
 ### Breaking Changes

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -297,6 +297,36 @@ from opentelemetry import trace
 tracer = trace.get_tracer("my-module")
 ```
 
+## Default Instrumentations With A365 exporter enabled
+
+The distro auto-discovers and activates supported OTel instrumentations.
+When `enable_a365=True`, the distro **disables web-framework /
+HTTP-client instrumentations by default**. GenAI instrumentations stay enabled.
+
+| Disabled by default with A365 | Enabled by default with A365 |
+|---|---|
+| `django` | `langchain` |
+| `fastapi` | `openai` |
+| `flask` | `openai_agents` |
+| `psycopg2` | `semantic_kernel` |
+| `requests` | `agent_framework` |
+| `urllib` | |
+| `urllib3` | |
+
+To re-enable any of these, pass `instrumentation_options`:
+
+```python
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    instrumentation_options={
+        "fastapi": {"enabled": True},
+    },
+)
+```
+
+When `enable_a365=False` (the default), all supported instrumentations
+remain enabled by default.
+
 ## Environment Variable Mapping
 
 | Old env var | New env var | Notes |

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -312,6 +312,7 @@ HTTP-client instrumentations by default**. GenAI instrumentations stay enabled.
 | `requests` | disabled |
 | `urllib` | disabled |
 | `urllib3` | disabled |
+| `azure_sdk` | disabled |
 | `openai` | enabled |
 | `openai_agents` | enabled |
 | `langchain` | enabled |

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -303,6 +303,11 @@ The distro auto-discovers and activates supported OTel instrumentations.
 When `enable_a365=True`, the distro **disables web-framework /
 HTTP-client instrumentations by default**. GenAI instrumentations stay enabled.
 
+> **Note:** When both `enable_a365=True` and `enable_azure_monitor=True` are
+> set, the original (non-A365) defaults are used and the libraries below
+> remain **enabled** so Azure Monitor continues to receive web/HTTP
+> telemetry.
+
 | Library | Default with A365 |
 |---|---|
 | `django` | disabled |

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -310,8 +310,8 @@ HTTP-client instrumentations by default**. GenAI instrumentations stay enabled.
 | `flask` | `openai_agents` |
 | `psycopg2` | `semantic_kernel` |
 | `requests` | `agent_framework` |
-| `urllib` | |
-| `urllib3` | |
+| `urllib`   |
+| `urllib3`  |
 
 To re-enable any of these, pass `instrumentation_options`:
 

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -303,15 +303,20 @@ The distro auto-discovers and activates supported OTel instrumentations.
 When `enable_a365=True`, the distro **disables web-framework /
 HTTP-client instrumentations by default**. GenAI instrumentations stay enabled.
 
-| Disabled by default with A365 | Enabled by default with A365 |
+| Library | Default with A365 |
 |---|---|
-| `django` | `langchain` |
-| `fastapi` | `openai` |
-| `flask` | `openai_agents` |
-| `psycopg2` | `semantic_kernel` |
-| `requests` | `agent_framework` |
-| `urllib`   |
-| `urllib3`  |
+| `django` | disabled |
+| `fastapi` | disabled |
+| `flask` | disabled |
+| `psycopg2` | disabled |
+| `requests` | disabled |
+| `urllib` | disabled |
+| `urllib3` | disabled |
+| `openai` | enabled |
+| `openai_agents` | enabled |
+| `langchain` | enabled |
+| `semantic_kernel` | enabled |
+| `agent_framework` | enabled |
 
 To re-enable any of these, pass `instrumentation_options`:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The distro automatically instruments the following libraries when they are insta
 | `openai` | GenAI |
 | `openai_agents` | GenAI |
 | `langchain` | GenAI |
+| `semantic_kernel` | GenAI |
+| `agent_framework` | GenAI |
 | `azure_sdk` | Azure (enabled when Azure Monitor is active) |
 
 Individual instrumentations can be toggled via the `instrumentation_options` kwarg:
@@ -201,15 +203,20 @@ use_microsoft_opentelemetry(
 The distro **automatically disables the
 following instrumentations by default** when `enable_a365=True`:
 
-| Disabled by default with A365 | Enabled by default with A365 |
+| Library | Default with A365 |
 |---|---|
-| `django` | `langchain` |
-| `fastapi` | `openai` |
-| `flask` | `openai_agents` |
-| `psycopg2` | `semantic_kernel` |
-| `requests` | `agent_framework` |
-| `urllib`  |
-| `urllib3` |
+| `django` | disabled |
+| `fastapi` | disabled |
+| `flask` | disabled |
+| `psycopg2` | disabled |
+| `requests` | disabled |
+| `urllib` | disabled |
+| `urllib3` | disabled |
+| `openai` | enabled |
+| `openai_agents` | enabled |
+| `langchain` | enabled |
+| `semantic_kernel` | enabled |
+| `agent_framework` | enabled |
 
 You can re-enable any of these explicitly via `instrumentation_options`:
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,35 @@ use_microsoft_opentelemetry(
 )
 ```
 
+### Default Instrumentations When `enable_a365=True`
+
+The distro **automatically disables the
+following instrumentations by default** when `enable_a365=True`:
+
+| Disabled by default with A365 | Enabled by default with A365 |
+|---|---|
+| `django` | `langchain` |
+| `fastapi` | `openai` |
+| `flask` | `openai_agents` |
+| `psycopg2` | `semantic_kernel` |
+| `requests` | `agent_framework` |
+| `urllib` | |
+| `urllib3` | |
+
+You can re-enable any of these explicitly via `instrumentation_options`:
+
+```python
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    instrumentation_options={
+        "fastapi": {"enabled": True},     # opt back in to FastAPI
+    },
+)
+```
+
+When `enable_a365=False` (the default), all supported instrumentations
+remain enabled by default.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ following instrumentations by default** when `enable_a365=True`:
 | `requests` | disabled |
 | `urllib` | disabled |
 | `urllib3` | disabled |
+| `azure_sdk` | disabled |
 | `openai` | enabled |
 | `openai_agents` | enabled |
 | `langchain` | enabled |

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ following instrumentations by default** when `enable_a365=True`:
 | `flask` | `openai_agents` |
 | `psycopg2` | `semantic_kernel` |
 | `requests` | `agent_framework` |
-| `urllib` | |
-| `urllib3` | |
+| `urllib`  |
+| `urllib3` |
 
 You can re-enable any of these explicitly via `instrumentation_options`:
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ following instrumentations by default** when `enable_a365=True`:
 | `urllib3` | disabled |
 | `azure_sdk` | disabled |
 | `openai` | enabled |
+
+> **Note:** When both `enable_a365=True` and `enable_azure_monitor=True` are
+> set, the original (non-A365) defaults are used and the disabled libraries
+> above remain **enabled** so Azure Monitor continues to receive web/HTTP
+> telemetry.
 | `openai_agents` | enabled |
 | `langchain` | enabled |
 | `semantic_kernel` | enabled |

--- a/src/microsoft/opentelemetry/_console/handler.py
+++ b/src/microsoft/opentelemetry/_console/handler.py
@@ -38,7 +38,7 @@ def create_console_components(
     """
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
     from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, PeriodicExportingMetricReader
-    from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor, ConsoleLogExporter
+    from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor, ConsoleLogRecordExporter
 
     components = ConsoleHandlers()
 
@@ -49,6 +49,6 @@ def create_console_components(
         components.metric_reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
 
     if enable_logs:
-        components.log_record_processor = SimpleLogRecordProcessor(ConsoleLogExporter())
+        components.log_record_processor = SimpleLogRecordProcessor(ConsoleLogRecordExporter())
 
     return components

--- a/src/microsoft/opentelemetry/_constants.py
+++ b/src/microsoft/opentelemetry/_constants.py
@@ -54,6 +54,7 @@ _A365_DISABLED_INSTRUMENTATIONS = (
     "requests",
     "urllib",
     "urllib3",
+    "azure_sdk",
 )
 
 # --- Console Exporter Constants ---

--- a/src/microsoft/opentelemetry/_constants.py
+++ b/src/microsoft/opentelemetry/_constants.py
@@ -44,6 +44,18 @@ _SUPPORTED_INSTRUMENTED_LIBRARIES = (
     "agent_framework",
 )
 
+# Libraries disabled by default when A365 is enabled (agent workloads
+# typically don't need web-framework / HTTP-client instrumentation).
+_A365_DISABLED_INSTRUMENTATIONS = (
+    "django",
+    "fastapi",
+    "flask",
+    "psycopg2",
+    "requests",
+    "urllib",
+    "urllib3",
+)
+
 # --- Console Exporter Constants ---
 
 ENABLE_CONSOLE_ARG = "enable_console"

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -47,6 +47,7 @@ from microsoft.opentelemetry._constants import (
     RESOURCE_ARG,
     SPAN_PROCESSORS_ARG,
     VIEWS_ARG,
+    _A365_DISABLED_INSTRUMENTATIONS,
     _AZURE_MONITOR_KWARG_MAP,
     _SUPPORTED_INSTRUMENTED_LIBRARIES,
     _SPECTRA_DEFAULT_GRPC_ENDPOINT,
@@ -164,6 +165,13 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:
     azure_monitor_kwargs: Dict[str, Any] = {
         _AZURE_MONITOR_KWARG_MAP[k]: v for k, v in kwargs.items() if k in _AZURE_MONITOR_KWARG_MAP
     }  # pylint: disable=line-too-long
+
+    # When A365 is enabled, disable web-framework / HTTP-client
+    # instrumentations by default.  The user can still override by
+    # explicitly setting ``instrumentation_options={"django": {"enabled": True}}``.
+    if enable_a365:
+        for lib in _A365_DISABLED_INSTRUMENTATIONS:
+            otel_kwargs.setdefault(INSTRUMENTATION_OPTIONS_ARG, {}).setdefault(lib, {}).setdefault("enabled", False)
 
     # ---- OTLP exporters (append to user-supplied processors/readers) ----
     _append_otlp_components(otel_kwargs)

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -66,7 +66,7 @@ from microsoft.opentelemetry._utils import (
 _logger = getLogger(__name__)
 
 
-def use_microsoft_opentelemetry(**kwargs: object) -> None:
+def use_microsoft_opentelemetry(**kwargs: object) -> None: # pylint: disable=too-many-statements
     """Configure OpenTelemetry with optional Azure Monitor support.
 
     This function sets up the OpenTelemetry global providers

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -166,10 +166,11 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None: # pylint: disable=too
         _AZURE_MONITOR_KWARG_MAP[k]: v for k, v in kwargs.items() if k in _AZURE_MONITOR_KWARG_MAP
     }  # pylint: disable=line-too-long
 
-    # When A365 is enabled, disable web-framework / HTTP-client
-    # instrumentations by default.  The user can still override by
-    # explicitly setting ``instrumentation_options={"django": {"enabled": True}}``.
-    if enable_a365:
+    # When A365 is enabled (and Azure Monitor is NOT enabled), disable
+    # web-framework / HTTP-client instrumentations by default.  The user can
+    # still override by explicitly setting
+    # ``instrumentation_options={"django": {"enabled": True}}``.
+    if enable_a365 and not enable_azure_monitor:
         inst_opts = otel_kwargs.get(INSTRUMENTATION_OPTIONS_ARG) or {}
         if not isinstance(inst_opts, dict):
             _logger.error(

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -170,8 +170,17 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:
     # instrumentations by default.  The user can still override by
     # explicitly setting ``instrumentation_options={"django": {"enabled": True}}``.
     if enable_a365:
+        inst_opts = otel_kwargs.get(INSTRUMENTATION_OPTIONS_ARG) or {}
+        if not isinstance(inst_opts, dict):
+            _logger.error(
+                "%s must be a dict, got %s; ignoring user value and using defaults.",
+                INSTRUMENTATION_OPTIONS_ARG,
+                type(inst_opts).__name__,
+            )
+            inst_opts = {}
         for lib in _A365_DISABLED_INSTRUMENTATIONS:
-            otel_kwargs.setdefault(INSTRUMENTATION_OPTIONS_ARG, {}).setdefault(lib, {}).setdefault("enabled", False)
+            inst_opts.setdefault(lib, {}).setdefault("enabled", False)
+        otel_kwargs[INSTRUMENTATION_OPTIONS_ARG] = inst_opts
 
     # ---- OTLP exporters (append to user-supplied processors/readers) ----
     _append_otlp_components(otel_kwargs)

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -19,6 +19,10 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 
+from microsoft.opentelemetry._constants import (
+    _A365_DISABLED_INSTRUMENTATIONS,
+    _SUPPORTED_INSTRUMENTED_LIBRARIES,
+)
 from microsoft.opentelemetry._distro import (
     use_microsoft_opentelemetry,
     _append_a365_components,
@@ -680,8 +684,10 @@ class TestSpectraComponents(unittest.TestCase):
 class TestA365DisablesWebInstrumentations(unittest.TestCase):
     """When enable_a365=True, web/DB instrumentations are off by default."""
 
-    _WEB_DB_LIBS = ("django", "fastapi", "flask", "psycopg2", "requests", "urllib", "urllib3")
-    _GENAI_LIBS = ("langchain", "openai", "openai_agents", "semantic_kernel", "agent_framework")
+    _WEB_DB_LIBS = _A365_DISABLED_INSTRUMENTATIONS
+    _GENAI_LIBS = tuple(
+        lib for lib in _SUPPORTED_INSTRUMENTED_LIBRARIES if lib not in _A365_DISABLED_INSTRUMENTATIONS
+    )
 
     @patch("microsoft.opentelemetry._distro._setup_instrumentations")
     @patch("microsoft.opentelemetry._distro._setup_logging")

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -23,6 +23,7 @@ from microsoft.opentelemetry._distro import (
     use_microsoft_opentelemetry,
     _append_a365_components,
     _append_spectra_components,
+    _is_instrumentation_enabled,
     _setup_tracing,
     _setup_metrics,
     _setup_logging,
@@ -409,7 +410,7 @@ class TestA365KwargsConfiguration(unittest.TestCase):
     @patch("microsoft.opentelemetry.a365.core.exporters.utils.is_agent365_exporter_enabled", return_value=True)
     @patch("microsoft.opentelemetry.a365.core.exporters.utils._create_default_token_resolver")
     def test_tenant_and_agent_ids_not_sourced_from_env(self, default_resolver_mock, enabled_mock):
-    
+
         default_resolver_mock.return_value = lambda aid, tid: "token"
 
         env = {
@@ -439,8 +440,10 @@ class TestA365KwargsConfiguration(unittest.TestCase):
         """a365_cluster_category kwarg takes precedence over A365_CLUSTER_CATEGORY env var."""
         default_resolver_mock.return_value = lambda aid, tid: "token"
 
-        with patch.dict("os.environ", {"A365_CLUSTER_CATEGORY": "mooncake"}, clear=False), \
-            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock:
+        with (
+            patch.dict("os.environ", {"A365_CLUSTER_CATEGORY": "mooncake"}, clear=False),
+            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock,
+        ):
             otel_kwargs = {"span_processors": []}
             _append_a365_components(True, otel_kwargs, cluster_category="gov")
 
@@ -453,8 +456,10 @@ class TestA365KwargsConfiguration(unittest.TestCase):
         """A365_CLUSTER_CATEGORY env var is used when kwarg not provided."""
         default_resolver_mock.return_value = lambda aid, tid: "token"
 
-        with patch.dict("os.environ", {"A365_CLUSTER_CATEGORY": "gov"}, clear=False), \
-            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock:
+        with (
+            patch.dict("os.environ", {"A365_CLUSTER_CATEGORY": "gov"}, clear=False),
+            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock,
+        ):
             otel_kwargs = {"span_processors": []}
             _append_a365_components(True, otel_kwargs)
 
@@ -468,8 +473,10 @@ class TestA365KwargsConfiguration(unittest.TestCase):
         default_resolver_mock.return_value = lambda aid, tid: "token"
 
         env = {k: v for k, v in os.environ.items() if k != "A365_CLUSTER_CATEGORY"}
-        with patch.dict("os.environ", env, clear=True), \
-            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock:
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter") as exporter_mock,
+        ):
             otel_kwargs = {"span_processors": []}
             _append_a365_components(True, otel_kwargs)
 
@@ -668,6 +675,76 @@ class TestSpectraComponents(unittest.TestCase):
         self.assertNotIn("spectra_endpoint", otel_kwargs)
         self.assertNotIn("spectra_protocol", otel_kwargs)
         self.assertNotIn("spectra_insecure", otel_kwargs)
+
+
+class TestA365DisablesWebInstrumentations(unittest.TestCase):
+    """When enable_a365=True, web/DB instrumentations are off by default."""
+
+    _WEB_DB_LIBS = ("django", "fastapi", "flask", "psycopg2", "requests", "urllib", "urllib3")
+    _GENAI_LIBS = ("langchain", "openai", "openai_agents", "semantic_kernel", "agent_framework")
+
+    @patch("microsoft.opentelemetry._distro._setup_instrumentations")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_web_db_disabled_when_a365_enabled(self, _trc, _met, _log, setup_inst):
+        """Web/DB libs are disabled by default when A365 is on."""
+        use_microsoft_opentelemetry(enable_a365=True)
+        otel_kwargs = setup_inst.call_args[0][0]
+        for lib in self._WEB_DB_LIBS:
+            self.assertFalse(
+                _is_instrumentation_enabled(otel_kwargs, lib),
+                f"{lib} should be disabled when enable_a365=True",
+            )
+
+    @patch("microsoft.opentelemetry._distro._setup_instrumentations")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_genai_still_enabled_when_a365_enabled(self, _trc, _met, _log, setup_inst):
+        """GenAI libs remain enabled when A365 is on."""
+        use_microsoft_opentelemetry(enable_a365=True)
+        otel_kwargs = setup_inst.call_args[0][0]
+        for lib in self._GENAI_LIBS:
+            self.assertTrue(
+                _is_instrumentation_enabled(otel_kwargs, lib),
+                f"{lib} should still be enabled when enable_a365=True",
+            )
+
+    @patch("microsoft.opentelemetry._distro._setup_instrumentations")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_user_can_override_disabled_lib(self, _trc, _met, _log, setup_inst):
+        """User can explicitly re-enable a web lib even with A365 on."""
+        use_microsoft_opentelemetry(
+            enable_a365=True,
+            instrumentation_options={"django": {"enabled": True}},
+        )
+        otel_kwargs = setup_inst.call_args[0][0]
+        self.assertTrue(
+            _is_instrumentation_enabled(otel_kwargs, "django"),
+            "django should be enabled when user explicitly overrides",
+        )
+        # Other web libs should still be disabled
+        self.assertFalse(
+            _is_instrumentation_enabled(otel_kwargs, "flask"),
+            "flask should still be disabled",
+        )
+
+    @patch("microsoft.opentelemetry._distro._setup_instrumentations")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_no_effect_when_a365_disabled(self, _trc, _met, _log, setup_inst):
+        """Without enable_a365, all instrumentations remain enabled by default."""
+        use_microsoft_opentelemetry()
+        otel_kwargs = setup_inst.call_args[0][0]
+        for lib in self._WEB_DB_LIBS:
+            self.assertTrue(
+                _is_instrumentation_enabled(otel_kwargs, lib),
+                f"{lib} should be enabled when a365 is off",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -752,6 +752,28 @@ class TestA365DisablesWebInstrumentations(unittest.TestCase):
                 f"{lib} should be enabled when a365 is off",
             )
 
+    @patch("microsoft.opentelemetry._distro._append_azure_monitor_components", return_value=(None, None, None))
+    @patch("microsoft.opentelemetry._distro._setup_instrumentations")
+    @patch("microsoft.opentelemetry._distro._setup_logging")
+    @patch("microsoft.opentelemetry._distro._setup_metrics")
+    @patch("microsoft.opentelemetry._distro._setup_tracing")
+    def test_a365_defaults_skipped_when_azure_monitor_also_enabled(
+        self, _trc, _met, _log, setup_inst, _az
+    ):
+        """When both enable_a365 and enable_azure_monitor are True, the
+        non-A365 (original) defaults are preserved so web/HTTP libs stay on."""
+        use_microsoft_opentelemetry(
+            enable_a365=True,
+            enable_azure_monitor=True,
+            azure_monitor_connection_string=TEST_CONNECTION_STRING,
+        )
+        otel_kwargs = setup_inst.call_args[0][0]
+        for lib in self._WEB_DB_LIBS:
+            self.assertTrue(
+                _is_instrumentation_enabled(otel_kwargs, lib),
+                f"{lib} should remain enabled when both a365 and azure_monitor are on",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes - https://github.com/microsoft/opentelemetry-distro-python/issues/71