### PR TITLE
Add OTLP payload byte-size chunking to Agent365Exporter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ disable = [
     "too-many-arguments",
     "too-many-positional-arguments",
     "too-many-locals",
+    "too-many-instance-attributes",
+    "too-many-branches",
     "wrong-import-order",
     "ungrouped-imports",
     "unknown-option-value",

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -24,7 +24,10 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import StatusCode
 
 from microsoft.opentelemetry.a365.core.exporters.utils import (
+    DEFAULT_MAX_PAYLOAD_BYTES,
     build_export_url,
+    chunk_by_size,
+    estimate_span_bytes,
     get_validated_domain_override,
     hex_span_id,
     hex_trace_id,
@@ -61,15 +64,19 @@ class _Agent365Exporter(SpanExporter):
         token_resolver: Callable[[str, str], str | None],
         cluster_category: str = "prod",
         use_s2s_endpoint: bool = False,
+        max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
     ):
         if token_resolver is None:
             raise ValueError("token_resolver must be provided.")
+        if max_payload_bytes <= 0:
+            raise ValueError(f"max_payload_bytes must be positive, got {max_payload_bytes}")
         self._session = requests.Session()
         self._closed = False
         self._lock = threading.Lock()
         self._token_resolver = token_resolver
         self._cluster_category = cluster_category
         self._use_s2s_endpoint = use_s2s_endpoint
+        self._max_payload_bytes = max_payload_bytes
         self._domain_override = get_validated_domain_override()
 
     # ------------- SpanExporter API -----------------
@@ -93,8 +100,23 @@ class _Agent365Exporter(SpanExporter):
 
             any_failure = False
             for (tenant_id, agent_id), activities in groups.items():
-                payload = self._build_export_request(activities)
-                body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+                # Map and truncate spans first, then chunk by estimated byte size
+                mapped_spans = self._map_and_truncate_spans(activities)
+                resource_attrs = self._get_resource_attributes(activities)
+                chunks = chunk_by_size(
+                    mapped_spans,
+                    lambda ms: estimate_span_bytes(ms[0]),
+                    self._max_payload_bytes,
+                )
+
+                if len(chunks) > 1:
+                    logger.debug(
+                        "Split %d spans into %d chunks for tenantId: %s, agentId: %s",
+                        len(activities),
+                        len(chunks),
+                        tenant_id,
+                        agent_id,
+                    )
 
                 endpoint = self._domain_override or DEFAULT_ENDPOINT_URL
                 url = build_export_url(endpoint, agent_id, tenant_id, self._use_s2s_endpoint)
@@ -130,9 +152,52 @@ class _Agent365Exporter(SpanExporter):
                     any_failure = True
                     continue
 
-                ok = self._post_with_retries(url, body, headers)
-                if not ok:
-                    any_failure = True
+                # Send each chunk (all-or-nothing: fail group on first chunk failure)
+                group_failed = False
+                for i, chunk in enumerate(chunks):
+                    payload = self._build_envelope(chunk, resource_attrs)
+                    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+                    body_bytes = len(body.encode("utf-8"))
+                    logger.debug(
+                        "Sending chunk %d of %d (%d spans, %d bytes)",
+                        i + 1,
+                        len(chunks),
+                        len(chunk),
+                        body_bytes,
+                    )
+                    # Defensive check: the estimator covers per-span content but not
+                    # envelope overhead (resource attributes, scope wrappers). Warn if
+                    # the assembled body exceeds the configured limit so operators can
+                    # observe estimator drift before the server starts rejecting requests.
+                    if body_bytes > self._max_payload_bytes:
+                        logger.warning(
+                            "Chunk %d of %d body size (%d bytes) exceeds max_payload_bytes (%d); "
+                            "estimator may be under-counting envelope overhead. "
+                            "Tenant: %s, agent: %s, spans: %d.",
+                            i + 1,
+                            len(chunks),
+                            body_bytes,
+                            self._max_payload_bytes,
+                            tenant_id,
+                            agent_id,
+                            len(chunk),
+                        )
+
+                    ok = self._post_with_retries(url, body, headers)
+                    if not ok:
+                        logger.error(
+                            "Chunk %d of %d failed for tenant %s, agent %s",
+                            i + 1,
+                            len(chunks),
+                            tenant_id,
+                            agent_id,
+                        )
+                        any_failure = True
+                        group_failed = True
+                        break
+
+                if group_failed:
+                    continue
 
             return SpanExportResult.FAILURE if any_failure else SpanExportResult.SUCCESS
 
@@ -222,26 +287,45 @@ class _Agent365Exporter(SpanExporter):
 
     # ------------- Payload mapping ------------------
 
-    def _build_export_request(self, spans: Sequence[ReadableSpan]) -> dict[str, Any]:
-        scope_map: dict[tuple[str, str | None], list[dict[str, Any]]] = {}
+    def _map_and_truncate_spans(self, spans: Sequence[ReadableSpan]) -> list[tuple[dict[str, Any], str, str | None]]:
+        """Map ReadableSpans to OTLP dicts and apply per-span truncation.
 
+        Returns a list of (mapped_span, scope_name, scope_version) tuples so
+        that envelope grouping by instrumentation scope can be performed
+        efficiently after byte-size chunking.
+        """
+        result: list[tuple[dict[str, Any], str, str | None]] = []
         for sp in spans:
             scope = sp.instrumentation_scope
-            scope_key = (scope.name, scope.version)
-            scope_map.setdefault(scope_key, []).append(self._map_span(sp))
+            scope_name = scope.name if scope is not None else "unknown"
+            scope_version = scope.version if scope is not None else None
+            result.append((self._map_span(sp), scope_name, scope_version))
+        return result
 
-        scope_spans: list[dict[str, Any]] = []
-        for (name, version), mapped_spans in scope_map.items():
-            scope_spans.append(
-                {
-                    "scope": {"name": name, "version": version},
-                    "spans": mapped_spans,
-                }
-            )
-
-        resource_attrs: dict[str, Any] = {}
+    @staticmethod
+    def _get_resource_attributes(spans: Sequence[ReadableSpan]) -> dict[str, Any]:
+        """Extract resource attributes from the first span in the batch."""
         if spans:
-            resource_attrs = dict(getattr(spans[0].resource, "attributes", {}) or {})
+            return dict(getattr(spans[0].resource, "attributes", {}) or {})
+        return {}
+
+    def _build_envelope(
+        self,
+        mapped_spans: Sequence[tuple[dict[str, Any], str, str | None]],
+        resource_attrs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build an OTLP export request envelope from pre-mapped spans."""
+        scope_map: dict[tuple[str, str | None], list[dict[str, Any]]] = {}
+        for mapped_span, scope_name, scope_version in mapped_spans:
+            scope_map.setdefault((scope_name, scope_version), []).append(mapped_span)
+
+        scope_spans: list[dict[str, Any]] = [
+            {
+                "scope": {"name": name, "version": version},
+                "spans": spans,
+            }
+            for (name, version), spans in scope_map.items()
+        ]
 
         return {
             "resourceSpans": [

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter_options.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter_options.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Optional
 
+from microsoft.opentelemetry.a365.core.exporters.utils import DEFAULT_MAX_PAYLOAD_BYTES
+
 
 class Agent365ExporterOptions:
     """Configuration for Agent365Exporter.
@@ -30,6 +32,7 @@ class Agent365ExporterOptions:
         scheduled_delay_ms: int = 5000,
         exporter_timeout_ms: int = 30000,
         max_export_batch_size: int = 512,
+        max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
     ):
         """
         Args:
@@ -40,6 +43,10 @@ class Agent365ExporterOptions:
             scheduled_delay_ms: Delay between export batches (ms).
             exporter_timeout_ms: Timeout for the export operation (ms).
             max_export_batch_size: Maximum batch size for export operations.
+            max_payload_bytes: Upper bound on HTTP request body size in bytes. The exporter
+                splits per-identity batches into sub-batches whose estimated size stays under
+                this limit, providing headroom under the A365 1 MB server limit. Default is
+                900_000 (~100 KB headroom for estimator error and JSON envelope overhead).
         """
         self.cluster_category = cluster_category
         self.token_resolver = token_resolver
@@ -48,3 +55,4 @@ class Agent365ExporterOptions:
         self.scheduled_delay_ms = scheduled_delay_ms
         self.exporter_timeout_ms = exporter_timeout_ms
         self.max_export_batch_size = max_export_batch_size
+        self.max_payload_bytes = max_payload_bytes

--- a/src/microsoft/opentelemetry/a365/core/exporters/utils.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/utils.py
@@ -18,7 +18,7 @@ import threading
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TypeVar
 from urllib.parse import urlparse
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -237,6 +237,141 @@ def is_agent365_exporter_enabled() -> bool:
     """Check if Agent365 exporter is enabled via environment variable."""
     enable_exporter = os.getenv(ENABLE_A365_OBSERVABILITY_EXPORTER, "").lower()
     return enable_exporter in ("true", "1", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Span size estimation and byte-level chunking
+# ---------------------------------------------------------------------------
+
+# Default upper bound on HTTP request body size in bytes. Provides ~100 KB
+# headroom under the A365 1 MB server limit for estimator error and JSON/
+# envelope overhead (e.g. resource attributes and scope wrappers).
+DEFAULT_MAX_PAYLOAD_BYTES = 900_000
+
+# Overhead constant for OTLP JSON span fixed fields (traceId, spanId,
+# parentSpanId, kind, timestamps, status, scope wrapper, etc.). Intentionally
+# generous to account for serializer variance.
+_SPAN_BASE_OVERHEAD = 2000
+
+# Overhead per attribute in OTLP JSON format. Covers key/value JSON wrapping.
+_ATTR_OVERHEAD = 80
+
+# Overhead per event in OTLP JSON.
+_EVENT_OVERHEAD = 200
+
+
+# Extra bytes per character to account for JSON escaping (quotes,
+# backslashes, control characters, unicode escapes).  A factor of 1.1
+# covers typical real-world content; the base overhead constants
+# provide additional headroom.
+_JSON_ESCAPE_FACTOR = 1.1
+
+
+def _utf8_len(s: str) -> int:
+    return len(s.encode("utf-8"))
+
+
+def estimate_value_bytes(value: Any) -> int:
+    """Estimate the serialized byte size of a single attribute value in OTLP/HTTP JSON."""
+    if isinstance(value, str):
+        return 40 + int(_utf8_len(value) * _JSON_ESCAPE_FACTOR)
+    # bool is a subclass of int; check before sequence/list handling below
+    if isinstance(value, bool):
+        return 40
+    if isinstance(value, (list, tuple)):
+        if len(value) == 0:
+            return 60
+        first = value[0]
+        if isinstance(first, str):
+            total = 60
+            for s in value:
+                total += 40 + int(_utf8_len(str(s)) * _JSON_ESCAPE_FACTOR)
+            return total
+        return 60 + 50 * len(value)
+    return 40  # int/float/None/other
+
+
+def estimate_span_bytes(span: dict[str, Any]) -> int:
+    """Heuristic estimator for the serialized size of an OTLP span in HTTP JSON.
+
+    Uses generous constants tuned to over-estimate by ~25-50%, providing
+    headroom for JSON serializer variance (whitespace, enum representation,
+    integer-as-string).
+    """
+    total = _SPAN_BASE_OVERHEAD
+    name = span.get("name")
+    if isinstance(name, str):
+        total += _utf8_len(name)
+
+    attributes = span.get("attributes")
+    if attributes:
+        for key, value in attributes.items():
+            total += _ATTR_OVERHEAD
+            total += _utf8_len(str(key))
+            total += estimate_value_bytes(value)
+
+    events = span.get("events")
+    if events:
+        for ev in events:
+            total += _EVENT_OVERHEAD
+            ev_name = ev.get("name") if isinstance(ev, dict) else None
+            if isinstance(ev_name, str):
+                total += _utf8_len(ev_name)
+            ev_attrs = ev.get("attributes") if isinstance(ev, dict) else None
+            if ev_attrs:
+                for key, value in ev_attrs.items():
+                    total += _ATTR_OVERHEAD
+                    total += _utf8_len(str(key))
+                    total += estimate_value_bytes(value)
+    return total
+
+
+T = TypeVar("T")
+
+
+def chunk_by_size(
+    items: Sequence[T],
+    get_size: Callable[[T], int],
+    max_chunk_bytes: int,
+) -> list[list[T]]:
+    """Split items into sub-batches whose cumulative estimated size stays under ``max_chunk_bytes``.
+
+    Multi-item chunks are guaranteed to stay within the limit. A single item
+    whose estimated size exceeds ``max_chunk_bytes`` forms its own one-item
+    chunk (never silently dropped) even though that chunk exceeds the limit.
+
+    Invariants:
+    - Input order is preserved across chunks.
+    - Empty input produces empty output.
+    - No item is ever dropped.
+    - No chunk is ever empty.
+
+    Raises:
+        ValueError: If ``max_chunk_bytes`` is not positive, or if ``get_size``
+            returns a negative value for any item.
+    """
+    if max_chunk_bytes <= 0:
+        raise ValueError(f"max_chunk_bytes must be positive, got {max_chunk_bytes}")
+
+    chunks: list[list[T]] = []
+    current: list[T] = []
+    current_bytes = 0
+
+    for item in items:
+        item_bytes = get_size(item)
+        if item_bytes < 0:
+            raise ValueError(f"get_size returned a negative value ({item_bytes}); sizes must be non-negative")
+        if current and current_bytes + item_bytes > max_chunk_bytes:
+            chunks.append(current)
+            current = []
+            current_bytes = 0
+        current.append(item)
+        current_bytes += item_bytes
+
+    if current:
+        chunks.append(current)
+
+    return chunks
 
 
 _A365_DEFAULT_SCOPE = "api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite"
@@ -466,6 +601,7 @@ def create_a365_components(
             token_resolver=options.token_resolver,
             cluster_category=options.cluster_category,
             use_s2s_endpoint=options.use_s2s_endpoint,
+            max_payload_bytes=options.max_payload_bytes,
         )
     else:
         logger.warning(

--- a/tests/a365/test_exporter.py
+++ b/tests/a365/test_exporter.py
@@ -62,6 +62,14 @@ class TestAgent365ExporterInit(unittest.TestCase):
         with self.assertRaises(ValueError):
             _Agent365Exporter(token_resolver=None)
 
+    def test_raises_on_zero_max_payload_bytes(self):
+        with self.assertRaises(ValueError):
+            _Agent365Exporter(token_resolver=lambda a, t: "token", max_payload_bytes=0)
+
+    def test_raises_on_negative_max_payload_bytes(self):
+        with self.assertRaises(ValueError):
+            _Agent365Exporter(token_resolver=lambda a, t: "token", max_payload_bytes=-1)
+
     def test_creates_with_valid_resolver(self):
         exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
         self.assertIsNotNone(exporter)
@@ -158,7 +166,9 @@ class TestAgent365ExporterBuildRequest(unittest.TestCase):
     def test_build_export_request_structure(self):
         exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
         span = _make_span()
-        payload = exporter._build_export_request([span])
+        mapped_spans = exporter._map_and_truncate_spans([span])
+        resource_attrs = exporter._get_resource_attributes([span])
+        payload = exporter._build_envelope(mapped_spans, resource_attrs)
         self.assertIn("resourceSpans", payload)
         resource_spans = payload["resourceSpans"]
         self.assertEqual(len(resource_spans), 1)

--- a/tests/a365/test_payload_chunking.py
+++ b/tests/a365/test_payload_chunking.py
@@ -1,0 +1,244 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for payload byte-size chunking in the Agent365 exporter."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.trace import StatusCode
+
+from microsoft.opentelemetry.a365.core.exporters.agent365_exporter import (
+    _Agent365Exporter,
+)
+from microsoft.opentelemetry.a365.core.exporters.utils import (
+    chunk_by_size,
+    estimate_span_bytes,
+    estimate_value_bytes,
+    truncate_span,
+)
+
+
+def _make_otlp_span(attrs: dict, name: str = "test") -> dict:
+    return {
+        "traceId": "00000000000000000000000000000001",
+        "spanId": "0000000000000002",
+        "name": name,
+        "kind": "INTERNAL",
+        "startTimeUnixNano": 1000000000,
+        "endTimeUnixNano": 2000000000,
+        "attributes": attrs,
+        "events": None,
+        "links": None,
+        "status": {"code": "UNSET", "message": ""},
+    }
+
+
+class TestEstimateSpanBytes(unittest.TestCase):
+    def test_over_estimates_relative_to_actual_json_size(self) -> None:
+        span = _make_otlp_span(
+            {
+                "gen_ai.system": "openai",
+                "gen_ai.tool.arguments": "x" * 1000,
+                "gen_ai.tool.call_result": "y" * 1000,
+            }
+        )
+        actual = len(json.dumps(span).encode("utf-8"))
+        self.assertGreaterEqual(estimate_span_bytes(span), actual)
+
+    def test_grows_with_attribute_content(self) -> None:
+        small = _make_otlp_span({"key": "val"})
+        large = _make_otlp_span({"key": "x" * 10000})
+        self.assertGreater(estimate_span_bytes(large), estimate_span_bytes(small))
+
+    def test_accounts_for_events(self) -> None:
+        base = _make_otlp_span({})
+        with_events = {**base, "events": [{"name": "ev", "attributes": {"k": "v"}}]}
+        self.assertGreater(estimate_span_bytes(with_events), estimate_span_bytes(base))
+
+
+class TestEstimateValueBytes(unittest.TestCase):
+    def test_handles_all_value_types(self) -> None:
+        self.assertEqual(estimate_value_bytes("hello"), 40 + int(5 * 1.1))
+        self.assertEqual(estimate_value_bytes([]), 60)
+        self.assertEqual(estimate_value_bytes(["a", "bb"]), 60 + (40 + int(1 * 1.1)) + (40 + int(2 * 1.1)))
+        self.assertEqual(estimate_value_bytes([1, 2]), 60 + 50 * 2)
+        self.assertEqual(estimate_value_bytes(True), 40)
+        self.assertEqual(estimate_value_bytes(42), 40)
+        self.assertEqual(estimate_value_bytes(None), 40)
+
+
+class TestChunkBySize(unittest.TestCase):
+    def _get_size(self, item: dict) -> int:
+        return int(item["size"])
+
+    def test_empty_input_returns_empty_output(self) -> None:
+        self.assertEqual(chunk_by_size([], self._get_size, 900_000), [])
+
+    def test_small_items_fit_in_one_chunk(self) -> None:
+        items = [{"id": f"s{i}", "size": 100} for i in range(10)]
+        chunks = chunk_by_size(items, self._get_size, 900_000)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(len(chunks[0]), 10)
+
+    def test_splits_when_cumulative_exceeds_limit_and_preserves_order(self) -> None:
+        items = [{"id": f"s{i}", "size": 300_000} for i in range(5)]
+        chunks = chunk_by_size(items, self._get_size, 900_000)
+        self.assertGreaterEqual(len(chunks), 2)
+        flat_ids = [item["id"] for chunk in chunks for item in chunk]
+        self.assertEqual(flat_ids, ["s0", "s1", "s2", "s3", "s4"])
+
+    def test_oversize_single_item_gets_its_own_chunk(self) -> None:
+        chunks = chunk_by_size([{"id": "big", "size": 2_000_000}], self._get_size, 900_000)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0][0]["id"], "big")
+
+    def test_multi_item_chunks_respect_limit_no_chunk_is_empty(self) -> None:
+        items = [{"id": f"s{i}", "size": 200_000} for i in range(5)]
+        chunks = chunk_by_size(items, self._get_size, 500_000)
+        for chunk in chunks:
+            self.assertGreater(len(chunk), 0)
+            if len(chunk) > 1:
+                total = sum(self._get_size(item) for item in chunk)
+                self.assertLessEqual(total, 500_000)
+
+    def test_rejects_zero_max_chunk_bytes(self) -> None:
+        with self.assertRaises(ValueError):
+            chunk_by_size([{"id": "s", "size": 1}], self._get_size, 0)
+
+    def test_rejects_negative_max_chunk_bytes(self) -> None:
+        with self.assertRaises(ValueError):
+            chunk_by_size([{"id": "s", "size": 1}], self._get_size, -1)
+
+    def test_rejects_negative_item_size(self) -> None:
+        with self.assertRaises(ValueError):
+            chunk_by_size([{"id": "s", "size": -1}], self._get_size, 100)
+
+
+class TestTruncateSpanVerification(unittest.TestCase):
+    MAX = 250 * 1024
+
+    def test_leaves_small_span_unchanged(self) -> None:
+        span = _make_otlp_span({"k": "small"})
+        self.assertEqual(truncate_span(span)["attributes"]["k"], "small")
+
+    def test_shrinks_oversize_span_below_limit(self) -> None:
+        span = _make_otlp_span({"small": "ok", "fat": "x" * 300_000})
+        result = truncate_span(span)
+        self.assertLessEqual(len(json.dumps(result).encode("utf-8")), self.MAX)
+        self.assertEqual(result["attributes"]["small"], "ok")
+        self.assertEqual(result["attributes"]["fat"], "TRUNCATED")
+
+
+class TestExporterChunking(unittest.TestCase):
+    """End-to-end test: the exporter splits oversized batches into multiple HTTP requests."""
+
+    def setUp(self) -> None:
+        self.token_resolver = Mock(return_value="test_token")
+
+    def _make_span(self, span_id: int, attribute_size: int) -> ReadableSpan:
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = f"span_{span_id}"
+
+        ctx = Mock()
+        ctx.trace_id = 0x1
+        ctx.span_id = span_id
+        mock_span.context = ctx
+        mock_span.parent = None
+        mock_span.start_time = 1640995200000000000
+        mock_span.end_time = 1640995260000000000
+
+        status = Mock()
+        status.status_code = StatusCode.OK
+        status.description = ""
+        mock_span.status = status
+
+        kind = Mock()
+        kind.name = "INTERNAL"
+        mock_span.kind = kind
+
+        mock_span.attributes = {
+            "microsoft.tenant.id": "tenant-1",
+            "gen_ai.agent.id": "agent-1",
+            "payload": "x" * attribute_size,
+        }
+        mock_span.events = []
+        mock_span.links = []
+
+        scope = Mock()
+        scope.name = "test.scope"
+        scope.version = "1.0"
+        mock_span.instrumentation_scope = scope
+
+        resource = Mock()
+        resource.attributes = {"service.name": "test"}
+        mock_span.resource = resource
+        return mock_span
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_oversized_batch_is_split_into_multiple_requests(self) -> None:
+        exporter = _Agent365Exporter(
+            token_resolver=self.token_resolver,
+            cluster_category="test",
+            max_payload_bytes=300_000,
+        )
+
+        # Each span carries ~200 KB of payload; with a 300 KB chunk limit,
+        # 5 spans should yield at least 2 chunks.
+        spans = [self._make_span(span_id=i + 1, attribute_size=200_000) for i in range(5)]
+
+        with patch.object(exporter, "_post_with_retries", return_value=True) as mock_post:
+            result = exporter.export(spans)
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.assertGreaterEqual(mock_post.call_count, 2)
+
+        # Each chunk body must be valid JSON with the expected envelope structure.
+        total_spans_sent = 0
+        for call in mock_post.call_args_list:
+            _, body, _ = call.args
+            data = json.loads(body)
+            self.assertIn("resourceSpans", data)
+            scope_spans = data["resourceSpans"][0]["scopeSpans"]
+            for ss in scope_spans:
+                total_spans_sent += len(ss["spans"])
+        self.assertEqual(total_spans_sent, len(spans))
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_chunk_failure_short_circuits_remaining_chunks(self) -> None:
+        exporter = _Agent365Exporter(
+            token_resolver=self.token_resolver,
+            cluster_category="test",
+            max_payload_bytes=300_000,
+        )
+        spans = [self._make_span(span_id=i + 1, attribute_size=200_000) for i in range(5)]
+
+        with patch.object(exporter, "_post_with_retries", return_value=False) as mock_post:
+            result = exporter.export(spans)
+
+        self.assertEqual(result, SpanExportResult.FAILURE)
+        # First chunk fails; remaining chunks must not be sent.
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_small_batch_uses_single_request(self) -> None:
+        exporter = _Agent365Exporter(
+            token_resolver=self.token_resolver,
+            cluster_category="test",
+        )
+        spans = [self._make_span(span_id=1, attribute_size=100)]
+
+        with patch.object(exporter, "_post_with_retries", return_value=True) as mock_post:
+            result = exporter.export(spans)
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.assertEqual(mock_post.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Port upstream Agent365-python PR #248 (commit d08cf0a).

A365 OTLP traces endpoint enforces a 1 MB request body limit. The exporter previously batched by span count (512) with no byte-level enforcement, so batches of gen-AI spans could exceed 1 MB and get rejected.

Changes:
- Add heuristic span size estimator (estimate_span_bytes) with generous over-estimation
- Add byte-size chunking (chunk_by_size) that splits per-identity batches into sub-batches under max_payload_bytes (default 900 KB, configurable via Agent365ExporterOptions)
- Refactor _build_export_request into _map_and_truncate_spans, _get_resource_attributes, and _build_envelope to support chunking
- All-or-nothing semantics: if any chunk fails, the entire batch fails and the BatchExportProcessor retries
- Add max_payload_bytes to Agent365ExporterOptions
- Add 17 tests covering estimation, chunking, and end-to-end exporter behavior