### PR TITLE
Add SDKStats module with Azure Monitor bridge for feature/instrumentation reporting

### DIFF
--- a/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
+++ b/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
@@ -75,8 +75,10 @@ def _mark_browser_loader_feature(is_enabled: bool) -> None:
             and not get_statsbeat_browser_sdk_loader_feature_set()
         ):
             set_statsbeat_browser_sdk_loader_feature_set()
-    except (ImportError, Exception):  # pylint: disable=broad-exception-caught
+    except ImportError:
         pass
+    except Exception:  # pylint: disable=broad-exception-caught
+        _logger.debug("Failed to record browser loader statsbeat usage", exc_info=True)
 
 
 # Web SDK snippet template

--- a/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
+++ b/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
@@ -50,12 +50,12 @@ def _mark_browser_loader_feature(is_enabled: bool) -> None:
     try:
         from microsoft.opentelemetry._sdkstats._state import (
             SdkStatsFeature,
-            is_sdkstats_enabled as _is_enabled,
+            is_sdkstats_enabled,
             get_sdkstats_shutdown,
             set_sdkstats_feature,
         )
 
-        if _is_enabled() and not get_sdkstats_shutdown():
+        if is_sdkstats_enabled() and not get_sdkstats_shutdown():
             set_sdkstats_feature(SdkStatsFeature.AZURE_MONITOR_BROWSER_SDK_LOADER)
     except Exception:  # pylint: disable=broad-exception-caught
         _logger.debug("Failed to record browser loader sdkstats usage", exc_info=True)

--- a/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
+++ b/src/microsoft/opentelemetry/_azure_monitor/_browser_sdk_loader/snippet_injector.py
@@ -35,13 +35,32 @@ _logger = getLogger(__name__)
 
 
 def _mark_browser_loader_feature(is_enabled: bool) -> None:
-    """Record browser SDK loader usage in statsbeat when available.
+    """Record browser SDK loader usage in SDKStats.
+
+    Uses the in-repo sdkstats module first, then falls back to the Azure
+    Monitor Exporter statsbeat for backward compatibility.
 
     :param is_enabled: Indicates whether the browser loader is enabled.
     :type is_enabled: bool
     """
     if not is_enabled:
         return
+
+    # Record via the in-repo sdkstats module (always available)
+    try:
+        from microsoft.opentelemetry._sdkstats._state import (
+            SdkStatsFeature,
+            is_sdkstats_enabled as _is_enabled,
+            get_sdkstats_shutdown,
+            set_sdkstats_feature,
+        )
+
+        if _is_enabled() and not get_sdkstats_shutdown():
+            set_sdkstats_feature(SdkStatsFeature.AZURE_MONITOR_BROWSER_SDK_LOADER)
+    except Exception:  # pylint: disable=broad-exception-caught
+        _logger.debug("Failed to record browser loader sdkstats usage", exc_info=True)
+
+    # Also propagate to the Azure Monitor Exporter statsbeat (if available)
     try:
         from azure.monitor.opentelemetry.exporter.statsbeat._state import (
             get_statsbeat_browser_sdk_loader_feature_set,
@@ -49,18 +68,15 @@ def _mark_browser_loader_feature(is_enabled: bool) -> None:
             is_statsbeat_enabled,
             set_statsbeat_browser_sdk_loader_feature_set,
         )
-    except ImportError:
-        return
 
-    try:
         if (
             is_statsbeat_enabled()
             and not get_statsbeat_shutdown()
             and not get_statsbeat_browser_sdk_loader_feature_set()
         ):
             set_statsbeat_browser_sdk_loader_feature_set()
-    except Exception:  # pylint: disable=broad-exception-caught
-        _logger.debug("Failed to record browser loader statsbeat usage", exc_info=True)
+    except (ImportError, Exception):  # pylint: disable=broad-exception-caught
+        pass
 
 
 # Web SDK snippet template

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -64,6 +64,14 @@ from microsoft.opentelemetry._constants import (
 )
 from microsoft.opentelemetry._instrumentation import get_dist_dependency_conflicts
 from microsoft.opentelemetry._otlp import is_otlp_enabled
+from microsoft.opentelemetry._sdkstats._state import (
+    SdkStatsFeature,
+    get_sdkstats_feature_flags,
+    get_sdkstats_instrumentation_flags,
+    is_sdkstats_enabled,
+    set_sdkstats_feature,
+    set_sdkstats_instrumentation_by_name,
+)
 from microsoft.opentelemetry._utils import (
     _append_azure_monitor_components,
     _append_console_components,
@@ -176,8 +184,7 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     :rtype: None
     """
 
-    os.environ[MICROSOFT_OPENTELEMETRY_VERSION_ENV] = VERSION
-    enable_azure_monitor = kwargs.pop(ENABLE_AZURE_MONITOR_ARG, False)
+    enable_azure_monitor: bool = bool(kwargs.pop(ENABLE_AZURE_MONITOR_ARG, False))
     enable_console: bool = bool(kwargs.pop(ENABLE_CONSOLE_ARG, False))
     enable_a365: bool = bool(kwargs.pop(ENABLE_A365_ARG, False))
     a365_token_resolver = kwargs.pop(A365_TOKEN_RESOLVER_ARG, None)
@@ -219,8 +226,13 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
             inst_opts.setdefault(lib, {}).setdefault("enabled", False)
         otel_kwargs[INSTRUMENTATION_OPTIONS_ARG] = inst_opts
 
+    # ---- SDKStats: record distro feature flag ----
+    set_sdkstats_feature(SdkStatsFeature.DISTRO)
+
     # ---- OTLP exporters (append to user-supplied processors/readers) ----
     _append_otlp_components(otel_kwargs)
+    if is_otlp_enabled():
+        set_sdkstats_feature(SdkStatsFeature.OTLP_EXPORT)
 
     # ---- Spectra sidecar exporter (OTLP gRPC/HTTP to localhost) ----
     _append_spectra_components(
@@ -252,6 +264,8 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     if not enable_console and not enable_azure_monitor and not enable_a365 and not is_otlp_enabled():
         enable_console = True
     _append_console_components(otel_kwargs, enable_console)
+    if enable_console:
+        set_sdkstats_feature(SdkStatsFeature.CONSOLE_EXPORT)
 
     # ---- Build and register providers ----
     tracer_provider: Optional[TracerProvider] = None
@@ -293,6 +307,9 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     # ---- Instrumentations (always, after providers are set) ----
     _setup_instrumentations(otel_kwargs)
 
+    # ---- SDKStats manager (after providers, before returning) ----
+    _initialize_sdkstats(enable_azure_monitor)
+
     if enable_azure_monitor:
         _logger.info("Azure Monitor enabled.")
 
@@ -303,6 +320,60 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if not val:
         return default
     return val in ("true", "1", "yes", "on")
+
+
+def _initialize_sdkstats(enable_azure_monitor: bool) -> None:
+    """Set up SDKStats — always sends to the Application Insights statsbeat endpoint.
+
+    When Azure Monitor is active the exporter package's own StatsbeatManager
+    handles everything and we bridge our distro-level feature/instrumentation
+    bits into its state so it reports the full picture.  For A365-only,
+    OTLP-only, or Console-only customers this function creates a standalone
+    pipeline using ``AzureMonitorMetricExporter(is_sdkstats=True)`` pointed
+    at the well-known statsbeat ingestion endpoint.  The customer's telemetry
+    pipeline is not affected.
+    """
+    if not is_sdkstats_enabled():
+        return
+
+    if enable_azure_monitor:
+        # The exporter package runs its own statsbeat.  Bridge our
+        # distro-level feature bits (A365_EXPORT, OTLP_EXPORT, etc.)
+        # and instrumentation bits into the exporter's state so they
+        # appear in the same observation.  Our bit values (128+) do
+        # not collide with the exporter's (1–64).
+        _bridge_sdkstats_to_azure_monitor()
+        return
+
+    from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+    manager = SdkStatsManager()
+    manager.initialize()
+
+
+def _bridge_sdkstats_to_azure_monitor() -> None:
+    """OR distro feature/instrumentation bits into the exporter's statsbeat."""
+    try:
+        from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+            _StatsbeatMetrics,
+        )
+        import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+
+        # Feature bits — OR our flags into the class-level dict that the
+        # exporter's _get_feature_metric callback reads each cycle.
+        feature_flags = get_sdkstats_feature_flags()
+        if feature_flags:
+            current = _StatsbeatMetrics._FEATURE_ATTRIBUTES.get("feature") or 0
+            _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = current | feature_flags
+
+        # Instrumentation bits — OR directly into the exporter's module-
+        # level bitmask (thread-safe via their lock).
+        instrumentation_flags = get_sdkstats_instrumentation_flags()
+        if instrumentation_flags:
+            with _exporter_utils._INSTRUMENTATIONS_BIT_MASK_LOCK:
+                _exporter_utils._INSTRUMENTATIONS_BIT_MASK |= instrumentation_flags
+    except Exception:  # pylint: disable=broad-exception-caught
+        _logger.debug("Failed to bridge SDKStats into Azure Monitor statsbeat.", exc_info=True)
 
 
 def _append_a365_components(
@@ -366,6 +437,8 @@ def _append_a365_components(
 
         otel_kwargs[SPAN_PROCESSORS_ARG] = list(otel_kwargs.get(SPAN_PROCESSORS_ARG) or [])
         otel_kwargs[SPAN_PROCESSORS_ARG].append(baggage_processor)
+
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
 
         # Resolve configuration: kwargs > env vars > defaults
         resolved_cluster_category = cluster_category or os.environ.get(A365_CLUSTER_CATEGORY_ENV, "prod")
@@ -619,6 +692,7 @@ def _setup_instrumentations(otel_kwargs: Dict[str, Any]) -> None:
                 continue
             instrumentor: Any = entry_point.load()
             instrumentor().instrument(skip_dep_check=True)
+            set_sdkstats_instrumentation_by_name(lib_name)
         except Exception as ex:  # pylint: disable=broad-except
             _logger.warning(
                 "Exception occurred when instrumenting: %s.",

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -518,6 +518,8 @@ def _append_spectra_components(
     """
     if not enable_spectra:
         return
+    
+    set_sdkstats_feature(SdkStatsFeature.SPECTRA_EXPORT)
 
     if otel_kwargs.get(DISABLE_TRACING_ARG, False):
         return

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -189,6 +189,7 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     :rtype: None
     """
 
+    os.environ[MICROSOFT_OPENTELEMETRY_VERSION_ENV] = VERSION
     enable_azure_monitor: bool = bool(kwargs.pop(ENABLE_AZURE_MONITOR_ARG, False))
     enable_console: bool = bool(kwargs.pop(ENABLE_CONSOLE_ARG, False))
     enable_a365: bool = bool(kwargs.pop(ENABLE_A365_ARG, False))

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -79,6 +79,11 @@ from microsoft.opentelemetry._utils import (
 )
 from microsoft.opentelemetry._version import VERSION
 
+import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+    _StatsbeatMetrics,
+)
+
 _logger = getLogger(__name__)
 
 
@@ -353,27 +358,19 @@ def _initialize_sdkstats(enable_azure_monitor: bool) -> None:
 
 def _bridge_sdkstats_to_azure_monitor() -> None:
     """OR distro feature/instrumentation bits into the exporter's statsbeat."""
-    try:
-        from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
-            _StatsbeatMetrics,
-        )
-        import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+    # Feature bits — OR our flags into the class-level dict that the
+    # exporter's _get_feature_metric callback reads each cycle.
+    feature_flags = get_sdkstats_feature_flags()
+    if feature_flags:
+        current = _StatsbeatMetrics._FEATURE_ATTRIBUTES.get("feature") or 0
+        _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = current | feature_flags
 
-        # Feature bits — OR our flags into the class-level dict that the
-        # exporter's _get_feature_metric callback reads each cycle.
-        feature_flags = get_sdkstats_feature_flags()
-        if feature_flags:
-            current = _StatsbeatMetrics._FEATURE_ATTRIBUTES.get("feature") or 0
-            _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = current | feature_flags
-
-        # Instrumentation bits — OR directly into the exporter's module-
-        # level bitmask (thread-safe via their lock).
-        instrumentation_flags = get_sdkstats_instrumentation_flags()
-        if instrumentation_flags:
-            with _exporter_utils._INSTRUMENTATIONS_BIT_MASK_LOCK:
-                _exporter_utils._INSTRUMENTATIONS_BIT_MASK |= instrumentation_flags
-    except Exception:  # pylint: disable=broad-exception-caught
-        _logger.debug("Failed to bridge SDKStats into Azure Monitor statsbeat.", exc_info=True)
+    # Instrumentation bits — OR directly into the exporter's module-
+    # level bitmask (thread-safe via their lock).
+    instrumentation_flags = get_sdkstats_instrumentation_flags()
+    if instrumentation_flags:
+        with _exporter_utils._INSTRUMENTATIONS_BIT_MASK_LOCK:
+            _exporter_utils._INSTRUMENTATIONS_BIT_MASK |= instrumentation_flags
 
 
 def _append_a365_components(

--- a/src/microsoft/opentelemetry/_sdkstats/__init__.py
+++ b/src/microsoft/opentelemetry/_sdkstats/__init__.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""SDK self-telemetry (SDKStats) for the Microsoft OpenTelemetry Distro.
+
+This module provides backend-agnostic SDK health and usage telemetry that
+works regardless of which export backends are enabled (Azure Monitor, OTLP,
+A365, Console).  It tracks:
+
+- **Features**: which distro features are active (disk retry, AAD, live
+  metrics, browser SDK loader, etc.)
+- **Instrumentations**: which library instrumentations are enabled (Django,
+  FastAPI, OpenAI, LangChain, etc.)
+
+The module is initialised by :func:`use_microsoft_opentelemetry` during
+distro setup and sends metrics to the Application Insights statsbeat
+ingestion endpoint via ``AzureMonitorMetricExporter``.
+"""
+
+from microsoft.opentelemetry._sdkstats._state import (
+    get_sdkstats_feature_flags,
+    get_sdkstats_instrumentation_flags,
+    is_sdkstats_enabled,
+    set_sdkstats_feature,
+    set_sdkstats_instrumentation,
+    set_sdkstats_shutdown,
+)
+from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+__all__ = [
+    "SdkStatsManager",
+    "get_sdkstats_feature_flags",
+    "get_sdkstats_instrumentation_flags",
+    "is_sdkstats_enabled",
+    "set_sdkstats_feature",
+    "set_sdkstats_instrumentation",
+    "set_sdkstats_shutdown",
+]

--- a/src/microsoft/opentelemetry/_sdkstats/_manager.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_manager.py
@@ -1,0 +1,208 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""SDKStats manager — sends SDK self-telemetry to Application Insights.
+
+SDKStats always sends metrics to the Application Insights statsbeat
+ingestion endpoint via ``AzureMonitorMetricExporter``.  This is
+independent of the customer's telemetry pipeline — the exporter
+targets a well-known Microsoft-owned iKey/endpoint used for SDK
+health monitoring.
+
+When the full Azure Monitor pipeline is enabled the exporter package's
+own ``StatsbeatManager`` handles everything.  For A365-only, OTLP-only,
+or Console-only customers this manager creates a standalone
+``MeterProvider`` → ``AzureMonitorMetricExporter(is_sdkstats=True)``
+pipeline so usage/feature metrics are still collected.
+"""
+
+import logging
+import threading
+from typing import Optional
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    MetricReader,
+    PeriodicExportingMetricReader,
+)
+from opentelemetry.sdk.resources import Resource
+
+from microsoft.opentelemetry._sdkstats._state import (
+    is_sdkstats_enabled,
+    set_sdkstats_shutdown,
+)
+from microsoft.opentelemetry._sdkstats._metrics import SdkStatsMetrics
+
+_logger = logging.getLogger(__name__)
+
+# Default export interval: 15 minutes (in seconds, converted to ms for reader)
+_DEFAULT_EXPORT_INTERVAL_SECS = 900
+
+
+class SdkStatsManager:
+    """Singleton manager for SDK self-telemetry metrics.
+
+    Creates a standalone ``MeterProvider`` with an
+    ``AzureMonitorMetricExporter(is_sdkstats=True)`` that sends
+    feature/instrumentation gauges to the well-known statsbeat
+    ingestion endpoint.  This is completely independent of any
+    customer-facing Azure Monitor configuration.
+
+    Call :meth:`initialize` once during distro setup.  The manager is
+    safe to initialise from multiple threads — only the first call
+    takes effect.
+    """
+
+    _instance: Optional["SdkStatsManager"] = None
+    _instance_lock = threading.Lock()
+
+    def __new__(cls) -> "SdkStatsManager":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False  # type: ignore[attr-defined]
+        return cls._instance
+
+    def __init__(self) -> None:
+        # Guard against re-init on repeated __init__ calls from __new__
+        if getattr(self, "_init_done", False):
+            return
+        self._init_done = True
+        self._lock = threading.Lock()
+        self._initialized = False
+        self._meter_provider: Optional[MeterProvider] = None
+        self._metrics: Optional[SdkStatsMetrics] = None
+
+    # ------------------------------------------------------------------
+    # Public initialisation
+    # ------------------------------------------------------------------
+
+    def initialize(self) -> bool:
+        """Set up SDKStats export via Azure Monitor statsbeat endpoint.
+
+        Uses ``AzureMonitorMetricExporter`` with ``is_sdkstats=True``
+        pointed at the default (non-EU) statsbeat connection string.
+        The exporter package resolves EU vs non-EU automatically when
+        a customer endpoint hint is provided.
+        """
+        if not is_sdkstats_enabled():
+            return False
+
+        with self._lock:
+            if self._initialized:
+                return True
+            return self._do_initialize()
+
+    def initialize_standalone(self, metric_reader: MetricReader) -> bool:
+        """Set up SDKStats with a caller-supplied metric reader.
+
+        Intended for tests or future transports.
+        """
+        if not is_sdkstats_enabled():
+            return False
+
+        with self._lock:
+            if self._initialized:
+                return True
+            return self._do_initialize_with_reader(metric_reader)
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    def shutdown(self) -> bool:
+        with self._lock:
+            if not self._initialized:
+                return False
+            try:
+                if self._meter_provider is not None:
+                    self._meter_provider.shutdown()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+            self._meter_provider = None
+            self._metrics = None
+            self._initialized = False
+            set_sdkstats_shutdown(True)
+            return True
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _do_initialize(self) -> bool:
+        """Create an AzureMonitorMetricExporter for statsbeat."""
+        try:
+            from azure.monitor.opentelemetry.exporter.statsbeat._utils import (
+                _get_stats_connection_string,
+                _get_stats_short_export_interval,
+            )
+            from azure.monitor.opentelemetry.exporter.export.metrics._exporter import (
+                AzureMonitorMetricExporter,
+            )
+
+            # Use the well-known non-EU statsbeat endpoint as default.
+            # The helper honours APPLICATIONINSIGHTS_STATS_CONNECTION_STRING
+            # env-var overrides automatically.
+            stats_connection_string = _get_stats_connection_string(
+                "https://defaultendpoint.in.applicationinsights.azure.com/"
+            )
+            export_interval_secs = _get_stats_short_export_interval()
+
+            exporter = AzureMonitorMetricExporter(
+                connection_string=stats_connection_string,
+                disable_offline_storage=True,
+                is_sdkstats=True,
+            )
+
+            reader = PeriodicExportingMetricReader(
+                exporter,
+                export_interval_millis=export_interval_secs * 1000,
+            )
+            return self._do_initialize_with_reader(reader)
+
+        except ImportError:
+            _logger.debug("azure-monitor-opentelemetry-exporter is not available; SDKStats will not be exported.")
+            return False
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.warning("Failed to create SDKStats Azure Monitor exporter.", exc_info=True)
+            return False
+
+    def _do_initialize_with_reader(self, reader: MetricReader) -> bool:
+        try:
+            self._meter_provider = MeterProvider(
+                metric_readers=[reader],
+                resource=Resource.get_empty(),
+            )
+            self._metrics = SdkStatsMetrics(self._meter_provider)
+            self._initialized = True
+            _logger.debug("SDKStats initialised.")
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.warning("Failed to initialise SDKStats.", exc_info=True)
+            self._cleanup()
+            return False
+
+    def _cleanup(self) -> None:
+        if self._meter_provider:
+            try:
+                self._meter_provider.shutdown()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        self._meter_provider = None
+        self._metrics = None
+        self._initialized = False
+
+    @classmethod
+    def _reset(cls) -> None:
+        """Reset the singleton — intended for tests only."""
+        with cls._instance_lock:
+            if cls._instance is not None:
+                cls._instance.shutdown()
+            cls._instance = None

--- a/src/microsoft/opentelemetry/_sdkstats/_manager.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_manager.py
@@ -38,9 +38,6 @@ from microsoft.opentelemetry._sdkstats._metrics import SdkStatsMetrics
 
 _logger = logging.getLogger(__name__)
 
-# Default export interval: 15 minutes (in seconds, converted to ms for reader)
-_DEFAULT_EXPORT_INTERVAL_SECS = 900
-
 
 class SdkStatsManager:
     """Singleton manager for SDK self-telemetry metrics.

--- a/src/microsoft/opentelemetry/_sdkstats/_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_metrics.py
@@ -29,8 +29,7 @@ class _FeatureTypes:
     INSTRUMENTATION = 1
 
 
-_ATTACH_METRIC_NAME = "Attach"
-_FEATURE_METRIC_NAME = "Feature"
+_FEATURE_METRIC_NAME = "feature"
 
 
 class SdkStatsMetrics:

--- a/src/microsoft/opentelemetry/_sdkstats/_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_metrics.py
@@ -10,7 +10,7 @@ Mirrors the Azure Monitor Exporter ``_StatsbeatMetrics`` feature/
 instrumentation gauge pattern, but is backend-agnostic — the metrics are
 collected into a caller-supplied ``MeterProvider``.
 """
-
+from enum import Enum
 import platform
 from typing import Any, Dict, Iterable, List
 
@@ -23,8 +23,19 @@ from microsoft.opentelemetry._sdkstats._state import (
 )
 from microsoft.opentelemetry._version import VERSION
 
+class _RP_Names(Enum):
+    APP_SERVICE = "appsvc"
+    FUNCTIONS = "functions"
+    AKS = "aks"
+    VM = "vm"
+    UNKNOWN = "unknown"
 
-class _FeatureTypes:
+class _AttachTypes(Enum):
+    MANUAL = "Manual"
+    INTEGRATED = "IntegratedAuto"
+    STANDALONE = "StandaloneAuto"
+
+class _FeatureTypes(Enum):
     FEATURE = 0
     INSTRUMENTATION = 1
 
@@ -45,6 +56,9 @@ class SdkStatsMetrics:
         self._distro_version = distro_version or VERSION
 
         self._common_attributes: Dict[str, Any] = {
+            "rp": _RP_Names.UNKNOWN.value,
+            "attach": _AttachTypes.MANUAL.value,
+            "cikey": None,
             "runtimeVersion": platform.python_version(),
             "os": platform.system(),
             "language": "python",
@@ -61,7 +75,7 @@ class SdkStatsMetrics:
 
         # Instrumentation gauge
         self._meter.create_observable_gauge(
-            _FEATURE_METRIC_NAME + ".instrumentations",
+            _FEATURE_METRIC_NAME,
             callbacks=[self._observe_instrumentations],
             unit="",
             description="SDKStats metric tracking enabled instrumentations",
@@ -75,7 +89,7 @@ class SdkStatsMetrics:
         if feature_bits != 0:
             attrs = dict(self._common_attributes)
             attrs["feature"] = feature_bits
-            attrs["type"] = _FeatureTypes.FEATURE
+            attrs["type"] = _FeatureTypes.FEATURE.value
             observations.append(Observation(1, attrs))
         return observations
 
@@ -85,6 +99,6 @@ class SdkStatsMetrics:
         if instr_bits != 0:
             attrs = dict(self._common_attributes)
             attrs["feature"] = instr_bits
-            attrs["type"] = _FeatureTypes.INSTRUMENTATION
+            attrs["type"] = _FeatureTypes.INSTRUMENTATION.value
             observations.append(Observation(1, attrs))
         return observations

--- a/src/microsoft/opentelemetry/_sdkstats/_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_metrics.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Observable metric callbacks for SDK self-telemetry.
+
+Mirrors the Azure Monitor Exporter ``_StatsbeatMetrics`` feature/
+instrumentation gauge pattern, but is backend-agnostic — the metrics are
+collected into a caller-supplied ``MeterProvider``.
+"""
+
+import platform
+from typing import Any, Dict, Iterable, List
+
+from opentelemetry.metrics import CallbackOptions, Observation
+from opentelemetry.sdk.metrics import MeterProvider
+
+from microsoft.opentelemetry._sdkstats._state import (
+    get_sdkstats_feature_flags,
+    get_sdkstats_instrumentation_flags,
+)
+from microsoft.opentelemetry._version import VERSION
+
+
+class _FeatureTypes:
+    FEATURE = 0
+    INSTRUMENTATION = 1
+
+
+_ATTACH_METRIC_NAME = "Attach"
+_FEATURE_METRIC_NAME = "Feature"
+
+
+class SdkStatsMetrics:
+    """Registers observable gauges that emit feature/instrumentation data."""
+
+    def __init__(
+        self,
+        meter_provider: MeterProvider,
+        *,
+        distro_version: str = "",
+    ) -> None:
+        self._meter = meter_provider.get_meter("microsoft.opentelemetry.sdkstats")
+        self._distro_version = distro_version or VERSION
+
+        self._common_attributes: Dict[str, Any] = {
+            "runtimeVersion": platform.python_version(),
+            "os": platform.system(),
+            "language": "python",
+            "version": self._distro_version,
+        }
+
+        # Feature gauge
+        self._meter.create_observable_gauge(
+            _FEATURE_METRIC_NAME,
+            callbacks=[self._observe_features],
+            unit="",
+            description="SDKStats metric tracking enabled features",
+        )
+
+        # Instrumentation gauge
+        self._meter.create_observable_gauge(
+            _FEATURE_METRIC_NAME + ".instrumentations",
+            callbacks=[self._observe_instrumentations],
+            unit="",
+            description="SDKStats metric tracking enabled instrumentations",
+        )
+
+    # ---- callbacks ----
+
+    def _observe_features(self, options: CallbackOptions) -> Iterable[Observation]:
+        observations: List[Observation] = []
+        feature_bits = get_sdkstats_feature_flags()
+        if feature_bits != 0:
+            attrs = dict(self._common_attributes)
+            attrs["feature"] = feature_bits
+            attrs["type"] = _FeatureTypes.FEATURE
+            observations.append(Observation(1, attrs))
+        return observations
+
+    def _observe_instrumentations(self, options: CallbackOptions) -> Iterable[Observation]:
+        observations: List[Observation] = []
+        instr_bits = get_sdkstats_instrumentation_flags()
+        if instr_bits != 0:
+            attrs = dict(self._common_attributes)
+            attrs["feature"] = instr_bits
+            attrs["type"] = _FeatureTypes.INSTRUMENTATION
+            observations.append(Observation(1, attrs))
+        return observations

--- a/src/microsoft/opentelemetry/_sdkstats/_state.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_state.py
@@ -1,0 +1,167 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Thread-safe global state for SDK self-telemetry (SDKStats).
+
+Feature and instrumentation flags are stored as bitmasks so they can be
+combined and reported efficiently.  The bitmask values are intentionally
+compatible with the Azure Monitor Exporter statsbeat encoding so that
+Azure Monitor consumers see no behavioural change.
+"""
+
+import os
+import threading
+from enum import IntFlag
+
+# ---------------------------------------------------------------------------
+# Environment variable to disable SDKStats globally
+# ---------------------------------------------------------------------------
+
+_SDKSTATS_DISABLED_ENV = "MICROSOFT_OTEL_SDKSTATS_DISABLED"
+
+# Also honour the legacy Azure Monitor variable
+_APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL = "APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL"
+
+
+# ---------------------------------------------------------------------------
+# Feature flags — bitmask values compatible with Azure Monitor statsbeat
+# ---------------------------------------------------------------------------
+
+
+class SdkStatsFeature(IntFlag):
+    """Bit flags for distro features tracked by SDKStats."""
+
+    NONE = 0
+    AZURE_MONITOR_DISK_RETRY = 1
+    AZURE_MONITOR_AAD = 2
+    AZURE_MONITOR_CUSTOM_EVENTS_EXTENSION = 4
+    DISTRO = 8
+    AZURE_MONITOR_LIVE_METRICS = 16
+    AZURE_MONITOR_CUSTOMER_SDKSTATS = 32
+    AZURE_MONITOR_BROWSER_SDK_LOADER = 64
+    A365_EXPORT = 128
+    OTLP_EXPORT = 256
+    CONSOLE_EXPORT = 512
+    SPECTRA_EXPORT = 1024
+
+
+# ---------------------------------------------------------------------------
+# Instrumentation flags — bitmask values compatible with Azure Monitor
+# ---------------------------------------------------------------------------
+
+
+class SdkStatsInstrumentation(IntFlag):
+    """Bit flags for library instrumentations tracked by SDKStats.
+
+    Values are kept in sync with the Azure Monitor Exporter
+    ``_INSTRUMENTATIONS_BIT_MAP`` so metrics are interoperable.
+    """
+
+    NONE = 0
+    DJANGO = 1
+    FLASK = 2
+    PSYCOPG2 = 64
+    REQUESTS = 1024
+    FASTAPI = 4194304
+    URLLIB = 68719476736
+    URLLIB3 = 137438953472
+    OPENAI_V2 = 4503599627370496
+    # GenAI / agent instrumentations tracked by this distro
+    LANGCHAIN = 1 << 55
+    OPENAI_AGENTS = 1 << 56
+    SEMANTIC_KERNEL = 1 << 57
+    AGENT_FRAMEWORK = 1 << 58
+
+
+# Mapping from instrumentation entry-point name → bit flag
+_INSTRUMENTATION_NAME_MAP = {
+    "django": SdkStatsInstrumentation.DJANGO,
+    "flask": SdkStatsInstrumentation.FLASK,
+    "psycopg2": SdkStatsInstrumentation.PSYCOPG2,
+    "requests": SdkStatsInstrumentation.REQUESTS,
+    "fastapi": SdkStatsInstrumentation.FASTAPI,
+    "urllib": SdkStatsInstrumentation.URLLIB,
+    "urllib3": SdkStatsInstrumentation.URLLIB3,
+    "openai": SdkStatsInstrumentation.OPENAI_V2,
+    "openai_agents": SdkStatsInstrumentation.OPENAI_AGENTS,
+    "langchain": SdkStatsInstrumentation.LANGCHAIN,
+    "semantic_kernel": SdkStatsInstrumentation.SEMANTIC_KERNEL,
+    "agent_framework": SdkStatsInstrumentation.AGENT_FRAMEWORK,
+}
+
+
+# ---------------------------------------------------------------------------
+# Global mutable state (thread-safe)
+# ---------------------------------------------------------------------------
+
+_STATE_LOCK = threading.Lock()
+
+_SDKSTATS_STATE = {
+    "SHUTDOWN": False,
+    "FEATURE_FLAGS": SdkStatsFeature.NONE,
+    "INSTRUMENTATION_FLAGS": SdkStatsInstrumentation.NONE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def is_sdkstats_enabled() -> bool:
+    """Return ``True`` unless SDKStats has been disabled via env var."""
+    for env_var in (_SDKSTATS_DISABLED_ENV, _APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL):
+        val = os.environ.get(env_var, "").strip().lower()
+        if val in ("true", "1", "yes"):
+            return False
+    return True
+
+
+def set_sdkstats_shutdown(shutdown: bool = True) -> None:
+    with _STATE_LOCK:
+        _SDKSTATS_STATE["SHUTDOWN"] = shutdown
+
+
+def get_sdkstats_shutdown() -> bool:
+    return _SDKSTATS_STATE["SHUTDOWN"]  # type: ignore[return-value]
+
+
+# ---- Feature flags ----
+
+
+def set_sdkstats_feature(flag: SdkStatsFeature) -> None:
+    """Enable one or more feature flags (bitwise OR)."""
+    with _STATE_LOCK:
+        _SDKSTATS_STATE["FEATURE_FLAGS"] |= flag  # type: ignore[operator]
+
+
+def get_sdkstats_feature_flags() -> int:
+    """Return the current feature bitmask."""
+    return int(_SDKSTATS_STATE["FEATURE_FLAGS"])  # type: ignore[arg-type]
+
+
+# ---- Instrumentation flags ----
+
+
+def set_sdkstats_instrumentation(flag: SdkStatsInstrumentation) -> None:
+    """Enable one or more instrumentation flags (bitwise OR)."""
+    with _STATE_LOCK:
+        _SDKSTATS_STATE["INSTRUMENTATION_FLAGS"] |= flag  # type: ignore[operator]
+
+
+def set_sdkstats_instrumentation_by_name(name: str) -> None:
+    """Enable an instrumentation flag by its entry-point name.
+
+    Unknown names are silently ignored.
+    """
+    flag = _INSTRUMENTATION_NAME_MAP.get(name)
+    if flag:
+        set_sdkstats_instrumentation(flag)
+
+
+def get_sdkstats_instrumentation_flags() -> int:
+    """Return the current instrumentation bitmask."""
+    return int(_SDKSTATS_STATE["INSTRUMENTATION_FLAGS"])  # type: ignore[arg-type]

--- a/src/microsoft/opentelemetry/_sdkstats/_state.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_state.py
@@ -115,7 +115,7 @@ def is_sdkstats_enabled() -> bool:
     """Return ``True`` unless SDKStats has been disabled via env var."""
     for env_var in (_SDKSTATS_DISABLED_ENV, _APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL):
         val = os.environ.get(env_var, "").strip().lower()
-        if val in ("true", "1", "yes"):
+        if val in ("true", "1", "yes", "on"):
             return False
     return True
 

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -373,7 +373,7 @@ class TestSdkStatsManager(unittest.TestCase):
                     metric_names.add(metric.name)
 
         self.assertIn("feature", metric_names)
-        self.assertIn("feature.instrumentations", metric_names)
+        self.assertIn("feature", metric_names)
 
 
 class TestBridgeSdkStatsToAzureMonitor(unittest.TestCase):

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -66,6 +66,10 @@ class TestSdkStatsEnabled(unittest.TestCase):
         os.environ[_SDKSTATS_DISABLED_ENV] = "1"
         self.assertFalse(is_sdkstats_enabled())
 
+    def test_disabled_by_on(self):
+        os.environ[_SDKSTATS_DISABLED_ENV] = "on"
+        self.assertFalse(is_sdkstats_enabled())
+
     def test_enabled_with_random_value(self):
         os.environ[_SDKSTATS_DISABLED_ENV] = "banana"
         self.assertTrue(is_sdkstats_enabled())

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -1,0 +1,488 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Tests for the _sdkstats package — state, metrics, and manager."""
+
+import os
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from microsoft.opentelemetry._sdkstats._state import (
+    SdkStatsFeature,
+    SdkStatsInstrumentation,
+    _INSTRUMENTATION_NAME_MAP,
+    _SDKSTATS_DISABLED_ENV,
+    _APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL,
+    _SDKSTATS_STATE,
+    _STATE_LOCK,
+    get_sdkstats_feature_flags,
+    get_sdkstats_instrumentation_flags,
+    get_sdkstats_shutdown,
+    is_sdkstats_enabled,
+    set_sdkstats_feature,
+    set_sdkstats_instrumentation,
+    set_sdkstats_instrumentation_by_name,
+    set_sdkstats_shutdown,
+)
+
+
+def _reset_state():
+    """Reset module-level state between tests."""
+    with _STATE_LOCK:
+        _SDKSTATS_STATE["SHUTDOWN"] = False
+        _SDKSTATS_STATE["FEATURE_FLAGS"] = SdkStatsFeature.NONE
+        _SDKSTATS_STATE["INSTRUMENTATION_FLAGS"] = SdkStatsInstrumentation.NONE
+
+
+class TestSdkStatsEnabled(unittest.TestCase):
+    """Tests for is_sdkstats_enabled()."""
+
+    def setUp(self):
+        _reset_state()
+        # Clean env
+        os.environ.pop(_SDKSTATS_DISABLED_ENV, None)
+        os.environ.pop(_APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL, None)
+
+    def tearDown(self):
+        os.environ.pop(_SDKSTATS_DISABLED_ENV, None)
+        os.environ.pop(_APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL, None)
+
+    def test_enabled_by_default(self):
+        self.assertTrue(is_sdkstats_enabled())
+
+    def test_disabled_by_new_env_var(self):
+        os.environ[_SDKSTATS_DISABLED_ENV] = "true"
+        self.assertFalse(is_sdkstats_enabled())
+
+    def test_disabled_by_legacy_env_var(self):
+        os.environ[_APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL] = "True"
+        self.assertFalse(is_sdkstats_enabled())
+
+    def test_disabled_by_1(self):
+        os.environ[_SDKSTATS_DISABLED_ENV] = "1"
+        self.assertFalse(is_sdkstats_enabled())
+
+    def test_enabled_with_random_value(self):
+        os.environ[_SDKSTATS_DISABLED_ENV] = "banana"
+        self.assertTrue(is_sdkstats_enabled())
+
+
+class TestSdkStatsShutdown(unittest.TestCase):
+    """Tests for shutdown state."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_shutdown_default_false(self):
+        self.assertFalse(get_sdkstats_shutdown())
+
+    def test_set_shutdown(self):
+        set_sdkstats_shutdown(True)
+        self.assertTrue(get_sdkstats_shutdown())
+
+    def test_set_shutdown_false(self):
+        set_sdkstats_shutdown(True)
+        set_sdkstats_shutdown(False)
+        self.assertFalse(get_sdkstats_shutdown())
+
+
+class TestSdkStatsFeatureFlags(unittest.TestCase):
+    """Tests for feature flag state."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_default_none(self):
+        self.assertEqual(get_sdkstats_feature_flags(), 0)
+
+    def test_set_single_flag(self):
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        self.assertEqual(get_sdkstats_feature_flags(), SdkStatsFeature.DISTRO)
+
+    def test_set_multiple_flags(self):
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        set_sdkstats_feature(SdkStatsFeature.OTLP_EXPORT)
+        expected = SdkStatsFeature.DISTRO | SdkStatsFeature.OTLP_EXPORT
+        self.assertEqual(get_sdkstats_feature_flags(), expected)
+
+    def test_idempotent_set(self):
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
+        self.assertEqual(get_sdkstats_feature_flags(), SdkStatsFeature.A365_EXPORT)
+
+    def test_all_features_have_unique_bits(self):
+        seen = set()
+        for member in SdkStatsFeature:
+            if member == SdkStatsFeature.NONE:
+                continue
+            self.assertNotIn(int(member), seen, f"Duplicate bit for {member.name}")
+            seen.add(int(member))
+
+
+class TestSdkStatsInstrumentationFlags(unittest.TestCase):
+    """Tests for instrumentation flag state."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_default_none(self):
+        self.assertEqual(get_sdkstats_instrumentation_flags(), 0)
+
+    def test_set_by_enum(self):
+        set_sdkstats_instrumentation(SdkStatsInstrumentation.DJANGO)
+        self.assertEqual(
+            get_sdkstats_instrumentation_flags(),
+            SdkStatsInstrumentation.DJANGO,
+        )
+
+    def test_set_by_name(self):
+        set_sdkstats_instrumentation_by_name("fastapi")
+        self.assertEqual(
+            get_sdkstats_instrumentation_flags(),
+            SdkStatsInstrumentation.FASTAPI,
+        )
+
+    def test_set_unknown_name_ignored(self):
+        set_sdkstats_instrumentation_by_name("nonexistent_lib")
+        self.assertEqual(get_sdkstats_instrumentation_flags(), 0)
+
+    def test_multiple_instrumentations(self):
+        set_sdkstats_instrumentation_by_name("django")
+        set_sdkstats_instrumentation_by_name("openai")
+        expected = SdkStatsInstrumentation.DJANGO | SdkStatsInstrumentation.OPENAI_V2
+        self.assertEqual(get_sdkstats_instrumentation_flags(), expected)
+
+    def test_name_map_covers_supported_libraries(self):
+        """Every name in the map resolves to a non-zero flag."""
+        for name, flag in _INSTRUMENTATION_NAME_MAP.items():
+            self.assertNotEqual(flag, 0, f"Flag for {name} is zero")
+
+
+class TestSdkStatsThreadSafety(unittest.TestCase):
+    """Ensure concurrent flag updates are safe."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_concurrent_feature_flag_updates(self):
+        flags = list(SdkStatsFeature)
+        flags = [f for f in flags if f != SdkStatsFeature.NONE]
+        errors = []
+
+        def worker(flag):
+            try:
+                for _ in range(100):
+                    set_sdkstats_feature(flag)
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(f,)) for f in flags]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+
+        # All flags should be set
+        expected = SdkStatsFeature.NONE
+        for f in flags:
+            expected |= f
+        self.assertEqual(get_sdkstats_feature_flags(), expected)
+
+
+class TestSdkStatsMetrics(unittest.TestCase):
+    """Tests for the SdkStatsMetrics observable gauges."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_feature_observation_empty_when_no_flags(self):
+        from opentelemetry.sdk.metrics import MeterProvider
+        from microsoft.opentelemetry._sdkstats._metrics import SdkStatsMetrics
+
+        mp = MeterProvider()
+        try:
+            metrics = SdkStatsMetrics(mp)
+            obs = list(metrics._observe_features(MagicMock()))
+            self.assertEqual(obs, [])
+        finally:
+            mp.shutdown()
+
+    def test_feature_observation_emitted_with_flags(self):
+        from opentelemetry.sdk.metrics import MeterProvider
+        from microsoft.opentelemetry._sdkstats._metrics import SdkStatsMetrics
+
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        mp = MeterProvider()
+        try:
+            metrics = SdkStatsMetrics(mp)
+            obs = list(metrics._observe_features(MagicMock()))
+            self.assertEqual(len(obs), 1)
+            self.assertEqual(obs[0].value, 1)
+            attrs = obs[0].attributes
+            assert attrs is not None
+            self.assertEqual(attrs["feature"], int(SdkStatsFeature.DISTRO))
+            self.assertEqual(attrs["type"], 0)  # FEATURE
+        finally:
+            mp.shutdown()
+
+    def test_instrumentation_observation_emitted(self):
+        from opentelemetry.sdk.metrics import MeterProvider
+        from microsoft.opentelemetry._sdkstats._metrics import SdkStatsMetrics
+
+        set_sdkstats_instrumentation(SdkStatsInstrumentation.FASTAPI)
+        mp = MeterProvider()
+        try:
+            metrics = SdkStatsMetrics(mp)
+            obs = list(metrics._observe_instrumentations(MagicMock()))
+            self.assertEqual(len(obs), 1)
+            attrs = obs[0].attributes
+            assert attrs is not None
+            self.assertEqual(attrs["feature"], int(SdkStatsInstrumentation.FASTAPI))
+            self.assertEqual(attrs["type"], 1)  # INSTRUMENTATION
+        finally:
+            mp.shutdown()
+
+
+class TestSdkStatsManager(unittest.TestCase):
+    """Tests for the SdkStatsManager singleton."""
+
+    def setUp(self):
+        _reset_state()
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        SdkStatsManager._reset()
+
+    def tearDown(self):
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        SdkStatsManager._reset()
+
+    def test_singleton(self):
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        a = SdkStatsManager()
+        b = SdkStatsManager()
+        self.assertIs(a, b)
+
+    def test_initialize_standalone(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        reader = InMemoryMetricReader()
+        manager = SdkStatsManager()
+        result = manager.initialize_standalone(reader)
+        self.assertTrue(result)
+        self.assertTrue(manager.is_initialized)
+
+    def test_initialize_standalone_disabled(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        os.environ[_SDKSTATS_DISABLED_ENV] = "true"
+        try:
+            reader = InMemoryMetricReader()
+            manager = SdkStatsManager()
+            result = manager.initialize_standalone(reader)
+            self.assertFalse(result)
+            self.assertFalse(manager.is_initialized)
+        finally:
+            os.environ.pop(_SDKSTATS_DISABLED_ENV, None)
+
+    def test_shutdown(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        reader = InMemoryMetricReader()
+        manager = SdkStatsManager()
+        manager.initialize_standalone(reader)
+        result = manager.shutdown()
+        self.assertTrue(result)
+        self.assertFalse(manager.is_initialized)
+        self.assertTrue(get_sdkstats_shutdown())
+
+    def test_shutdown_when_not_initialized(self):
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        manager = SdkStatsManager()
+        result = manager.shutdown()
+        self.assertFalse(result)
+
+    def test_double_initialize_is_idempotent(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        reader1 = InMemoryMetricReader()
+        reader2 = InMemoryMetricReader()
+        manager = SdkStatsManager()
+        self.assertTrue(manager.initialize_standalone(reader1))
+        self.assertTrue(manager.initialize_standalone(reader2))  # Should return True (already init)
+
+    _FAKE_STATS_CS = "InstrumentationKey=fake;" + "IngestionEndpoint=https://test.in.applicationinsights.azure.com/"
+
+    @patch("azure.monitor.opentelemetry.exporter.export.metrics._exporter.AzureMonitorMetricExporter")
+    @patch(
+        "azure.monitor.opentelemetry.exporter.statsbeat._utils._get_stats_connection_string",
+        return_value=_FAKE_STATS_CS,
+    )
+    @patch(
+        "azure.monitor.opentelemetry.exporter.statsbeat._utils._get_stats_short_export_interval",
+        return_value=900,
+    )
+    def test_initialize_uses_azure_monitor_exporter(self, mock_interval, mock_cs, mock_exporter):
+        """initialize() must use AzureMonitorMetricExporter with is_sdkstats=True."""
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        manager = SdkStatsManager()
+        result = manager.initialize()
+        self.assertTrue(result)
+        self.assertTrue(manager.is_initialized)
+
+        mock_exporter.assert_called_once_with(
+            connection_string=self._FAKE_STATS_CS,
+            disable_offline_storage=True,
+            is_sdkstats=True,
+        )
+
+    def test_metrics_collected_after_initialize(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from microsoft.opentelemetry._sdkstats._manager import SdkStatsManager
+
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
+        set_sdkstats_instrumentation(SdkStatsInstrumentation.OPENAI_V2)
+
+        reader = InMemoryMetricReader()
+        manager = SdkStatsManager()
+        manager.initialize_standalone(reader)
+
+        metrics_data = reader.get_metrics_data()
+        self.assertIsNotNone(metrics_data)
+        metric_names = set()
+        for resource_metrics in metrics_data.resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    metric_names.add(metric.name)
+
+        self.assertIn("feature", metric_names)
+        self.assertIn("feature.instrumentations", metric_names)
+
+
+class TestBridgeSdkStatsToAzureMonitor(unittest.TestCase):
+    """Tests for _bridge_sdkstats_to_azure_monitor in _distro.py."""
+
+    def setUp(self):
+        _reset_state()
+        # Reset exporter state that the bridge touches
+        try:
+            from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+                _StatsbeatMetrics,
+            )
+            import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+
+            _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = None
+            with _exporter_utils._INSTRUMENTATIONS_BIT_MASK_LOCK:
+                _exporter_utils._INSTRUMENTATIONS_BIT_MASK = 0
+        except ImportError:
+            pass
+
+    def tearDown(self):
+        _reset_state()
+        # Reset exporter state touched by the bridge
+        try:
+            from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+                _StatsbeatMetrics,
+            )
+            import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+
+            _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = None
+            with _exporter_utils._INSTRUMENTATIONS_BIT_MASK_LOCK:
+                _exporter_utils._INSTRUMENTATIONS_BIT_MASK = 0
+        except ImportError:
+            pass
+
+    def test_bridge_feature_flags_into_exporter(self):
+        """Distro feature flags are OR'd into the exporter's _FEATURE_ATTRIBUTES."""
+        from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+            _StatsbeatMetrics,
+        )
+        from microsoft.opentelemetry._distro import _bridge_sdkstats_to_azure_monitor
+
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
+        _bridge_sdkstats_to_azure_monitor()
+
+        expected = int(SdkStatsFeature.DISTRO | SdkStatsFeature.A365_EXPORT)
+        self.assertEqual(_StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"], expected)
+
+    def test_bridge_preserves_existing_exporter_feature_flags(self):
+        """Bridge OR's into existing exporter bits, doesn't overwrite."""
+        from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+            _StatsbeatMetrics,
+        )
+        from microsoft.opentelemetry._distro import _bridge_sdkstats_to_azure_monitor
+
+        # Simulate exporter has already set DISK_RETRY=1 and AAD=2
+        _StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"] = 3
+        set_sdkstats_feature(SdkStatsFeature.OTLP_EXPORT)
+
+        _bridge_sdkstats_to_azure_monitor()
+
+        # 3 (existing) | 256 (OTLP_EXPORT) = 259
+        self.assertEqual(_StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"], 3 | 256)
+
+    def test_bridge_instrumentation_flags_into_exporter(self):
+        """Distro instrumentation flags are OR'd into the exporter's bitmask."""
+        import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+        from microsoft.opentelemetry._distro import _bridge_sdkstats_to_azure_monitor
+
+        set_sdkstats_instrumentation(SdkStatsInstrumentation.FASTAPI)
+        set_sdkstats_instrumentation(SdkStatsInstrumentation.LANGCHAIN)
+        _bridge_sdkstats_to_azure_monitor()
+
+        expected = int(SdkStatsInstrumentation.FASTAPI | SdkStatsInstrumentation.LANGCHAIN)
+        self.assertEqual(_exporter_utils._INSTRUMENTATIONS_BIT_MASK, expected)
+
+    def test_bridge_noop_when_no_flags(self):
+        """Bridge does nothing when no flags are set."""
+        from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
+            _StatsbeatMetrics,
+        )
+        import azure.monitor.opentelemetry.exporter._utils as _exporter_utils
+        from microsoft.opentelemetry._distro import _bridge_sdkstats_to_azure_monitor
+
+        _bridge_sdkstats_to_azure_monitor()
+
+        self.assertIsNone(_StatsbeatMetrics._FEATURE_ATTRIBUTES["feature"])
+        self.assertEqual(_exporter_utils._INSTRUMENTATIONS_BIT_MASK, 0)
+
+    def test_initialize_sdkstats_bridges_when_azure_monitor_enabled(self):
+        """_initialize_sdkstats calls the bridge when enable_azure_monitor=True."""
+        from microsoft.opentelemetry._distro import _initialize_sdkstats
+
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+        set_sdkstats_feature(SdkStatsFeature.A365_EXPORT)
+
+        with patch("microsoft.opentelemetry._distro._bridge_sdkstats_to_azure_monitor") as mock_bridge:
+            _initialize_sdkstats(enable_azure_monitor=True)
+            mock_bridge.assert_called_once()
+
+    def test_initialize_sdkstats_uses_manager_when_azure_monitor_disabled(self):
+        """_initialize_sdkstats creates SdkStatsManager when Azure Monitor is off."""
+        from microsoft.opentelemetry._distro import _initialize_sdkstats
+
+        set_sdkstats_feature(SdkStatsFeature.DISTRO)
+
+        with patch("microsoft.opentelemetry._sdkstats._manager.SdkStatsManager") as mock_cls:
+            mock_manager = MagicMock()
+            mock_cls.return_value = mock_manager
+            _initialize_sdkstats(enable_azure_monitor=False)
+            mock_manager.initialize.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- New _sdkstats : state management, observable metrics, and manager for SDK self-telemetry (feature flags and instrumentation bitmasks)
- Feature bits aligned with Azure Monitor exporter statsbeat encoding: bits 1-64 match exporter, bits 128+ are distro-specific (A365_EXPORT, OTLP_EXPORT, CONSOLE_EXPORT, SPECTRA_EXPORT)
- When Azure Monitor is enabled: bridge distro bits into exporter's statsbeat via _StatsbeatMetrics._FEATURE_ATTRIBUTES and _INSTRUMENTATIONS_BIT_MASK (single pipeline, no duplication)
- When Azure Monitor is disabled: standalone SdkStatsManager runs its own AzureMonitorMetricExporter(is_sdkstats=True) pipeline
- Distro records feature flags for each enabled exporter target and instrumentation bits for each activated library
