### PR TITLE
Auto-enable Agent Framework instrumentation and make agent-framework optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "opentelemetry-resource-detector-azure<1.0.0,>=0.1.5",
     "wrapt>=1.0",
     "opentelemetry-util-genai>=0.3b0",
+    "microsoft-agents-activity>=0.9.0",
+    "microsoft-agents-hosting-core>=0.9.0",
     "aiohttp>=3.8.0",
     "PyJWT",
     "requests"
@@ -53,8 +55,6 @@ langchain = [
 ]
 agent-framework = [
     "agent-framework>=1.0.0",
-    "microsoft-agents-activity>=0.9.0",
-    "microsoft-agents-hosting-core>=0.9.0",
 ]
 test = [
     "pytest>=8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,6 @@ dependencies = [
     "opentelemetry-resource-detector-azure<1.0.0,>=0.1.5",
     "wrapt>=1.0",
     "opentelemetry-util-genai>=0.3b0",
-    "microsoft-agents-activity>=0.9.0",
-    "microsoft-agents-hosting-core>=0.9.0",
     "aiohttp>=3.8.0",
     "PyJWT",
     "requests"
@@ -52,6 +50,11 @@ dependencies = [
 [project.optional-dependencies]
 langchain = [
     "langchain-core>=0.2.0",
+]
+agent-framework = [
+    "agent-framework>=1.0.0",
+    "microsoft-agents-activity>=0.9.0",
+    "microsoft-agents-hosting-core>=0.9.0",
 ]
 test = [
     "pytest>=8.0",

--- a/src/microsoft/opentelemetry/_agent_framework/_trace_instrumentor.py
+++ b/src/microsoft/opentelemetry/_agent_framework/_trace_instrumentor.py
@@ -20,8 +20,9 @@ class AgentFrameworkInstrumentor(BaseInstrumentor):
     """Instruments Agent Framework with OpenTelemetry observability.
 
     Automatically calls ``agent_framework.observability.enable_instrumentation()``
-    so the Agent Framework SDK emits OpenTelemetry spans.  When A365 export is
-    active, also registers a span enricher for attribute normalization.
+    so the Agent Framework SDK emits OpenTelemetry spans. When the A365 span
+    enricher pipeline is available, also registers a span enricher for
+    attribute normalization.
     """
 
     _processor: AgentFrameworkSpanProcessor | None = None
@@ -39,10 +40,11 @@ class AgentFrameworkInstrumentor(BaseInstrumentor):
 
             enable_instrumentation()
             self._af_instrumentation_enabled = True
-        except ImportError:
+        except ImportError as exc:
             _logger.debug(
-                "agent_framework package is not installed. "
-                + "Skipping Agent Framework SDK instrumentation enablement."
+                "Failed to import Agent Framework SDK instrumentation components. "
+                + "Skipping Agent Framework SDK instrumentation enablement.",
+                exc_info=exc,
             )
 
         provider = kwargs.get("tracer_provider") or get_tracer_provider()

--- a/src/microsoft/opentelemetry/_agent_framework/_trace_instrumentor.py
+++ b/src/microsoft/opentelemetry/_agent_framework/_trace_instrumentor.py
@@ -7,14 +7,9 @@ import logging
 from collections.abc import Collection
 from typing import Any
 
-from microsoft.opentelemetry.a365.core.exporters.enriching_span_processor import (
-    register_span_enricher,
-    unregister_span_enricher,
-)
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore[attr-defined]
 from opentelemetry.trace import get_tracer_provider
 
-from microsoft.opentelemetry._agent_framework._span_enricher import enrich_agent_framework_span
 from microsoft.opentelemetry._agent_framework._span_processor import AgentFrameworkSpanProcessor
 
 _logger = logging.getLogger(__name__)
@@ -22,29 +17,61 @@ _instruments = ("agent-framework >= 1.0.0",)
 
 
 class AgentFrameworkInstrumentor(BaseInstrumentor):
-    """Instruments Agent Framework with Agent365 observability."""
+    """Instruments Agent Framework with OpenTelemetry observability.
+
+    Automatically calls ``agent_framework.observability.enable_instrumentation()``
+    so the Agent Framework SDK emits OpenTelemetry spans.  When A365 export is
+    active, also registers a span enricher for attribute normalization.
+    """
 
     _processor: AgentFrameworkSpanProcessor | None = None
     _owns_enricher: bool = False
+    _af_instrumentation_enabled: bool = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
+        # Enable the Agent Framework SDK's built-in span generation so users
+        # don't need to call enable_instrumentation() manually.
+        try:
+            from agent_framework.observability import enable_instrumentation
+
+            enable_instrumentation()
+            self._af_instrumentation_enabled = True
+        except ImportError:
+            _logger.debug(
+                "agent_framework package is not installed. "
+                + "Skipping Agent Framework SDK instrumentation enablement."
+            )
+
         provider = kwargs.get("tracer_provider") or get_tracer_provider()
 
         self._processor = AgentFrameworkSpanProcessor()
         provider.add_span_processor(self._processor)  # type: ignore[union-attr, attr-defined]
 
+        # Register the A365 span enricher when the A365 pipeline is available.
         try:
+            from microsoft.opentelemetry.a365.core.exporters.enriching_span_processor import register_span_enricher
+            from microsoft.opentelemetry._agent_framework._span_enricher import enrich_agent_framework_span
+
             register_span_enricher(enrich_agent_framework_span)
             self._owns_enricher = True
+        except ImportError:
+            _logger.debug("A365 enricher modules not available. Skipping enricher registration.")
         except RuntimeError:
             _logger.debug("A span enricher is already registered. Skipping Agent Framework enricher registration.")
 
     def _uninstrument(self, **kwargs: Any) -> None:
         if self._owns_enricher:
-            unregister_span_enricher()
+            try:
+                from microsoft.opentelemetry.a365.core.exporters.enriching_span_processor import (
+                    unregister_span_enricher,
+                )
+
+                unregister_span_enricher()
+            except ImportError:
+                pass
             self._owns_enricher = False
 
         if self._processor is not None:

--- a/tests/agent_framework/test_trace_instrumentor.py
+++ b/tests/agent_framework/test_trace_instrumentor.py
@@ -117,6 +117,101 @@ class TestAgentFrameworkInstrumentor(unittest.TestCase):
             sys.modules.pop("agent_framework.observability", None)
             sys.modules.update(saved)
 
+    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
+    def test_instrument_works_without_a365_modules(self, mock_get_provider):
+        """When A365 modules cannot be imported (e.g. azure-monitor-only setup),
+        the instrumentor must still add the span processor and not raise."""
+        mock_provider = MagicMock()
+        mock_get_provider.return_value = mock_provider
+
+        import sys
+
+        a365_keys = [k for k in list(sys.modules) if k.startswith("microsoft.opentelemetry.a365")]
+        saved = {k: sys.modules.pop(k) for k in a365_keys}
+
+        try:
+            # Block A365 imports
+            sys.modules["microsoft.opentelemetry.a365"] = None  # type: ignore[assignment]
+            sys.modules["microsoft.opentelemetry.a365.core"] = None  # type: ignore[assignment]
+            sys.modules["microsoft.opentelemetry.a365.core.exporters"] = None  # type: ignore[assignment]
+            _enr_key = "microsoft.opentelemetry.a365.core.exporters.enriching_span_processor"
+            sys.modules[_enr_key] = None  # type: ignore[assignment]
+
+            instrumentor = AgentFrameworkInstrumentor()
+            instrumentor._instrument()
+
+            # Span processor must still be added even without A365 available.
+            mock_provider.add_span_processor.assert_called_once()
+            args, _ = mock_provider.add_span_processor.call_args
+            self.assertIsInstance(args[0], AgentFrameworkSpanProcessor)
+            # Enricher ownership must be False when A365 import fails.
+            self.assertFalse(instrumentor._owns_enricher)
+
+            # _uninstrument must also degrade gracefully.
+            instrumentor._uninstrument()
+        finally:
+            for k in [
+                "microsoft.opentelemetry.a365",
+                "microsoft.opentelemetry.a365.core",
+                "microsoft.opentelemetry.a365.core.exporters",
+                "microsoft.opentelemetry.a365.core.exporters.enriching_span_processor",
+            ]:
+                sys.modules.pop(k, None)
+            sys.modules.update(saved)
+
+    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
+    def test_enable_instrumentation_called_in_azure_monitor_only_scenario(self, mock_get_provider):
+        """The AF SDK must be enabled even when A365 isn't available — this is
+        the Azure-Monitor-only scenario where users want AF spans in App Insights."""
+        mock_provider = MagicMock()
+        mock_get_provider.return_value = mock_provider
+        mock_enable = MagicMock()
+
+        import sys
+
+        # Hide A365 modules to simulate azure-monitor-only setup
+        a365_keys = [k for k in list(sys.modules) if k.startswith("microsoft.opentelemetry.a365")]
+        saved_a365 = {k: sys.modules.pop(k) for k in a365_keys}
+
+        try:
+            _enr_key = "microsoft.opentelemetry.a365.core.exporters.enriching_span_processor"
+            sys.modules[_enr_key] = None  # type: ignore[assignment]
+
+            with patch.dict(
+                "sys.modules",
+                {
+                    "agent_framework": MagicMock(),
+                    "agent_framework.observability": MagicMock(enable_instrumentation=mock_enable),
+                },
+            ):
+                instrumentor = AgentFrameworkInstrumentor()
+                instrumentor._instrument()
+
+            # AF SDK enabled, span processor added, enricher NOT registered.
+            mock_enable.assert_called_once()
+            self.assertTrue(instrumentor._af_instrumentation_enabled)
+            mock_provider.add_span_processor.assert_called_once()
+            self.assertFalse(instrumentor._owns_enricher)
+        finally:
+            sys.modules.pop("microsoft.opentelemetry.a365.core.exporters.enriching_span_processor", None)
+            sys.modules.update(saved_a365)
+
+    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
+    def test_uninstrument_when_enricher_not_owned(self, mock_get_provider):
+        """_uninstrument must not call unregister_span_enricher when the
+        instrumentor doesn't own the enricher (e.g. another instrumentor
+        registered first, or A365 modules weren't available)."""
+        mock_get_provider.return_value = MagicMock()
+
+        with patch(
+            "microsoft.opentelemetry.a365.core.exporters.enriching_span_processor.unregister_span_enricher"
+        ) as mock_unregister:
+            instrumentor = AgentFrameworkInstrumentor()
+            # Don't call _instrument(); _owns_enricher stays False.
+            instrumentor._uninstrument()
+
+            mock_unregister.assert_not_called()
+
 
 class TestAgentFrameworkSpanProcessor(unittest.TestCase):
     """Unit tests for AgentFrameworkSpanProcessor (no-op)."""

--- a/tests/agent_framework/test_trace_instrumentor.py
+++ b/tests/agent_framework/test_trace_instrumentor.py
@@ -17,9 +17,14 @@ class TestAgentFrameworkInstrumentor(unittest.TestCase):
 
     def setUp(self):
         unregister_span_enricher()
+        # Reset the BaseInstrumentor singleton so each test gets a fresh instance.
+        AgentFrameworkInstrumentor._instance = None
+        AgentFrameworkInstrumentor._is_instrumented_by_opentelemetry = False
 
     def tearDown(self):
         unregister_span_enricher()
+        AgentFrameworkInstrumentor._instance = None
+        AgentFrameworkInstrumentor._is_instrumented_by_opentelemetry = False
 
     def test_instrumentor_initialization(self):
         instrumentor = AgentFrameworkInstrumentor()
@@ -46,7 +51,7 @@ class TestAgentFrameworkInstrumentor(unittest.TestCase):
         args, _ = mock_provider.add_span_processor.call_args
         self.assertIsInstance(args[0], AgentFrameworkSpanProcessor)
 
-    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.register_span_enricher")
+    @patch("microsoft.opentelemetry.a365.core.exporters.enriching_span_processor.register_span_enricher")
     @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
     def test_instrumentor_registers_enricher(self, mock_get_provider, mock_register):
         mock_get_provider.return_value = MagicMock()
@@ -56,8 +61,8 @@ class TestAgentFrameworkInstrumentor(unittest.TestCase):
 
         mock_register.assert_called_once()
 
-    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.unregister_span_enricher")
-    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.register_span_enricher")
+    @patch("microsoft.opentelemetry.a365.core.exporters.enriching_span_processor.unregister_span_enricher")
+    @patch("microsoft.opentelemetry.a365.core.exporters.enriching_span_processor.register_span_enricher")
     @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
     def test_uninstrument(self, mock_get_provider, mock_register, mock_unregister):
         mock_get_provider.return_value = MagicMock()
@@ -67,6 +72,50 @@ class TestAgentFrameworkInstrumentor(unittest.TestCase):
         instrumentor._uninstrument()
 
         mock_unregister.assert_called_once()
+
+    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
+    def test_instrument_calls_enable_instrumentation_when_available(self, mock_get_provider):
+        mock_get_provider.return_value = MagicMock()
+        mock_enable = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "agent_framework": MagicMock(),
+                "agent_framework.observability": MagicMock(enable_instrumentation=mock_enable),
+            },
+        ):
+            instrumentor = AgentFrameworkInstrumentor()
+            instrumentor._instrument()
+
+        mock_enable.assert_called_once()
+        self.assertTrue(instrumentor._af_instrumentation_enabled)
+
+    @patch("microsoft.opentelemetry._agent_framework._trace_instrumentor.get_tracer_provider")
+    def test_instrument_skips_enable_when_af_not_installed(self, mock_get_provider):
+        mock_get_provider.return_value = MagicMock()
+
+        import sys
+
+        # Temporarily hide all agent_framework modules and block re-import
+        # by setting them to None in sys.modules.
+        saved = {}
+        keys_to_remove = [k for k in list(sys.modules) if k == "agent_framework" or k.startswith("agent_framework.")]
+        for k in keys_to_remove:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            sys.modules["agent_framework"] = None  # type: ignore[assignment]
+            sys.modules["agent_framework.observability"] = None  # type: ignore[assignment]
+
+            instrumentor = AgentFrameworkInstrumentor()
+            instrumentor._instrument()
+
+            self.assertFalse(instrumentor._af_instrumentation_enabled)
+        finally:
+            sys.modules.pop("agent_framework", None)
+            sys.modules.pop("agent_framework.observability", None)
+            sys.modules.update(saved)
 
 
 class TestAgentFrameworkSpanProcessor(unittest.TestCase):


### PR DESCRIPTION
- AgentFrameworkInstrumentor now calls agent_framework.observability.enable_instrumentation() automatically so users don't need to call it manually when using the distro.
- Move A365 enricher imports to lazy (try/except) so the instrumentor works without A365 pipeline modules.
- Add agent-framework as an optional dependency extra in pyproject.toml (pip install microsoft-opentelemetry[agent-framework]).
- Add tests for auto-enablement and graceful fallback when agent-framework is not installed.