### PR TITLE
docs: document custom SpanProcessor filtering in A365 migration guide

### DIFF
--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -381,7 +381,7 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
     def on_end(self, span: ReadableSpan):
         op = span.attributes.get("gen_ai.operation.name")
         if op not in self.A365_OPS:
-            # Create new SpanContext with trace_flags = 0 (UNSAMPLED)
+            # Create new SpanContext with trace_flags = 0
             span._context = SpanContext(
                 span.context.trace_id,
                 span.context.span_id,

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -350,6 +350,69 @@ use_microsoft_opentelemetry(
 When `enable_a365=False` (the default), all supported instrumentations
 remain enabled by default.
 
+## Custom SpanProcessors — Filtering Console Output
+
+By default, when `enable_console=True` (or any additional exporter is
+configured), **all** spans are exported — including framework-level spans
+(`agents.app.*`, `agents.turn.*`, `agents.connector.*`,
+`agents.authentication.*`). This can make local development noisy when you
+only care about the 4 A365 observability scopes:
+
+- `invoke_agent`
+- `Chat` (InferenceScope)
+- `execute_tool` (ExecuteToolScope)
+- `output_messages` (OutputScope)
+
+To filter output to only A365 scopes, pass a custom `SpanProcessor` via the
+`span_processors` parameter:
+
+```python
+from opentelemetry.trace import SpanContext, TraceFlags
+from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
+
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+
+class A365OnlySpanProcessor(SpanProcessor):
+    """Filter console/exporter output to only A365 observability scopes."""
+
+    A365_OPS = {"invoke_agent", "chat", "execute_tool", "output_messages"}
+
+    def on_start(self, span, parent_context=None):
+        """Mark non-A365 spans as unsampled at start time."""
+        op = span.attributes.get("gen_ai.operation.name")
+
+        if op not in self.A365_OPS:
+            # Create new SpanContext with trace_flags = 0 (UNSAMPLED)
+            span._context = SpanContext(
+                span.context.trace_id,
+                span.context.span_id,
+                span.context.is_remote,
+                TraceFlags(0),  # UNSAMPLED
+                span.context.trace_state,
+            )
+
+    def on_end(self, span: ReadableSpan):
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+    def shutdown(self):
+        pass
+
+
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    enable_console=True,
+    a365_token_resolver=my_token_resolver,
+    span_processors=[A365OnlySpanProcessor()],
+)
+```
+
+This leverages standard OpenTelemetry `SpanProcessor` APIs — you can adapt
+the filter logic to any criteria (span name, attributes, etc.).
+
 ## Environment Variable Mapping
 
 | Old env var | New env var | Notes |

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -399,7 +399,7 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
 
 use_microsoft_opentelemetry(
     enable_a365=True,
-    enable_console=False,
+    enable_console=True,
     a365_token_resolver=my_token_resolver,
     span_processors=[A365OnlyConsoleSpanProcessor()],
 )

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -363,50 +363,46 @@ only care about the 4 A365 observability scopes:
 - `execute_tool` (ExecuteToolScope)
 - `output_messages` (OutputScope)
 
-To filter output to only A365 scopes, pass a custom `SpanProcessor` via the
-`span_processors` parameter:
+To filter output to only A365 scopes, disable the built-in console exporter
+and supply your own `SpanProcessor` that filters in `on_end` (where span
+attributes such as `gen_ai.operation.name` are finalized):
 
 ```python
-from opentelemetry.trace import SpanContext, TraceFlags
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 
 from microsoft.opentelemetry import use_microsoft_opentelemetry
 
 
-class A365OnlySpanProcessor(SpanProcessor):
-    """Filter console/exporter output to only A365 observability scopes."""
+class A365OnlyConsoleSpanProcessor(SpanProcessor):
+    """Send only A365 observability spans to the console exporter."""
 
     A365_OPS = {"invoke_agent", "chat", "execute_tool", "output_messages"}
 
-    def on_start(self, span, parent_context=None):
-        """Mark non-A365 spans as unsampled at start time."""
-        op = span.attributes.get("gen_ai.operation.name")
+    def __init__(self):
+        self._console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
 
-        if op not in self.A365_OPS:
-            # Create new SpanContext with trace_flags = 0 (UNSAMPLED)
-            span._context = SpanContext(
-                span.context.trace_id,
-                span.context.span_id,
-                span.context.is_remote,
-                TraceFlags(0),  # UNSAMPLED
-                span.context.trace_state,
-            )
+    def on_start(self, span, parent_context=None):
+        self._console_processor.on_start(span, parent_context=parent_context)
 
     def on_end(self, span: ReadableSpan):
-        pass
+        op = span.attributes.get("gen_ai.operation.name")
+
+        if op in self.A365_OPS:
+            self._console_processor.on_end(span)
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return True
+        return self._console_processor.force_flush(timeout_millis)
 
     def shutdown(self):
-        pass
+        self._console_processor.shutdown()
 
 
 use_microsoft_opentelemetry(
     enable_a365=True,
-    enable_console=True,
+    enable_console=False,
     a365_token_resolver=my_token_resolver,
-    span_processors=[A365OnlySpanProcessor()],
+    span_processors=[A365OnlyConsoleSpanProcessor()],
 )
 ```
 

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -363,13 +363,12 @@ only care about the 4 A365 observability scopes:
 - `execute_tool` (ExecuteToolScope)
 - `output_messages` (OutputScope)
 
-To filter output to only A365 scopes, disable the built-in console exporter
-and supply your own `SpanProcessor` that filters in `on_end` (where span
-attributes such as `gen_ai.operation.name` are finalized):
+To filter output to only A365 scopes, pass a custom `SpanProcessor` via the
+`span_processors` parameter:
 
 ```python
+from opentelemetry.trace import SpanContext, TraceFlags
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 
 from microsoft.opentelemetry import use_microsoft_opentelemetry
 
@@ -392,10 +391,10 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
             )
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return self._console_processor.force_flush(timeout_millis)
+        return True
 
     def shutdown(self):
-        self._console_processor.shutdown()
+        pass
 
 
 use_microsoft_opentelemetry(

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -378,8 +378,8 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
 
     A365_OPS = {"invoke_agent", "chat", "execute_tool", "output_messages"}
 
-    def on_end(self, span: ReadableSpan):
-        op = span.attributes.get("gen_ai.operation.name")
+    def on_start(self, span, parent_context=None):
+        op = (span.attributes or {}).get("gen_ai.operation.name")
         if op not in self.A365_OPS:
             # Create new SpanContext with trace_flags = 0
             span._context = SpanContext(
@@ -390,11 +390,14 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
                 span.context.trace_state,
             )
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return True
+    def on_end(self, span: ReadableSpan):
+        pass
 
     def shutdown(self):
         pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 use_microsoft_opentelemetry(

--- a/MIGRATION_A365.md
+++ b/MIGRATION_A365.md
@@ -359,7 +359,7 @@ configured), **all** spans are exported — including framework-level spans
 only care about the 4 A365 observability scopes:
 
 - `invoke_agent`
-- `Chat` (InferenceScope)
+- `chat` (InferenceScope)
 - `execute_tool` (ExecuteToolScope)
 - `output_messages` (OutputScope)
 
@@ -379,17 +379,17 @@ class A365OnlyConsoleSpanProcessor(SpanProcessor):
 
     A365_OPS = {"invoke_agent", "chat", "execute_tool", "output_messages"}
 
-    def __init__(self):
-        self._console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
-
-    def on_start(self, span, parent_context=None):
-        self._console_processor.on_start(span, parent_context=parent_context)
-
     def on_end(self, span: ReadableSpan):
         op = span.attributes.get("gen_ai.operation.name")
-
-        if op in self.A365_OPS:
-            self._console_processor.on_end(span)
+        if op not in self.A365_OPS:
+            # Create new SpanContext with trace_flags = 0 (UNSAMPLED)
+            span._context = SpanContext(
+                span.context.trace_id,
+                span.context.span_id,
+                span.context.is_remote,
+                TraceFlags(0),  # UNSAMPLED
+                span.context.trace_state,
+            )
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return self._console_processor.force_flush(timeout_millis)


### PR DESCRIPTION
Add section showing how to use span_processors parameter to filter console/exporter output to only A365 observability scopes (invoke_agent, chat, execute_tool, output_messages). 

Fixes #86