### PR TITLE
Revert: Fix get_caller_pairs userId fallback

### DIFF
--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -130,7 +130,7 @@ class _Agent365Exporter(SpanExporter):
                     agent_id,
                 )
 
-                headers: dict[str, str] = {"content-type": "application/json"}
+                headers: dict[str, str | bytes] = {"content-type": "application/json"}
                 try:
                     token = self._token_resolver(agent_id, tenant_id)
                     if token:
@@ -227,7 +227,7 @@ class _Agent365Exporter(SpanExporter):
             return text[:max_length] + "..."
         return text
 
-    def _post_with_retries(self, url: str, body: str, headers: dict[str, str]) -> bool:
+    def _post_with_retries(self, url: str, body: str, headers: dict[str, str | bytes]) -> bool:
         for attempt in range(DEFAULT_MAX_RETRIES + 1):
             try:
                 resp = self._session.post(

--- a/src/microsoft/opentelemetry/a365/hosting/scope_helpers/utils.py
+++ b/src/microsoft/opentelemetry/a365/hosting/scope_helpers/utils.py
@@ -63,7 +63,7 @@ def get_caller_pairs(activity: Activity) -> Iterator[tuple[str, Any]]:
     frm = activity.from_property
     if not frm:
         return
-    yield USER_ID_KEY, frm.aad_object_id or frm.agentic_user_id or frm.id
+    yield USER_ID_KEY, frm.aad_object_id
     yield USER_NAME_KEY, frm.name
     yield USER_EMAIL_KEY, frm.agentic_user_id
 

--- a/tests/a365/hosting/scope_helpers/test_scope_helper_utils.py
+++ b/tests/a365/hosting/scope_helpers/test_scope_helper_utils.py
@@ -83,64 +83,6 @@ def test_get_channel_pairs():
     assert (CHANNEL_LINK_KEY, None) in result
 
 
-def test_get_caller_pairs_fallback_to_frm_id():
-    """Test get_caller_pairs falls back to frm.id when aad_object_id is None (non-Teams channel)."""
-    from_account = ChannelAccount(
-        id="slack-user-123",
-        name="Slack User",
-        agentic_user_id=None,
-        aad_object_id=None,
-    )
-    activity = Activity(type="message", from_property=from_account)
-
-    result = list(get_caller_pairs(activity))
-
-    assert (USER_ID_KEY, "slack-user-123") in result
-
-
-def test_get_caller_pairs_fallback_to_agentic_user_id():
-    """Test get_caller_pairs falls back to agentic_user_id for A2A when aad_object_id is None."""
-    from_account = ChannelAccount(
-        id="raw-id",
-        name="Agent Caller",
-        agentic_user_id="agent-auid-456",
-        aad_object_id=None,
-    )
-    activity = Activity(type="message", from_property=from_account)
-
-    result = list(get_caller_pairs(activity))
-
-    assert (USER_ID_KEY, "agent-auid-456") in result
-
-
-def test_get_caller_pairs_aad_object_id_takes_precedence():
-    """Test get_caller_pairs uses aad_object_id when all identifiers are set."""
-    from_account = ChannelAccount(
-        id="raw-id",
-        name="Teams User",
-        agentic_user_id="agent-auid",
-        aad_object_id="aad-wins",
-    )
-    activity = Activity(type="message", from_property=from_account)
-
-    result = list(get_caller_pairs(activity))
-
-    assert (USER_ID_KEY, "aad-wins") in result
-
-
-def test_get_caller_pairs_a2a_guid_agentic_user_id():
-    """Test userId resolves to GUID AgenticUserId in A2A scenario."""
-    from_account = ChannelAccount(
-        id="29:1sH5NArUwkWAX",
-        name="Agent Caller",
-        agentic_user_id="bef730f4-d6f5-4ffb-b759-26ffa449ed7e",
-        aad_object_id=None,
-    )
-    activity = Activity(type="message", from_property=from_account)
-    result = list(get_caller_pairs(activity))
-    assert (USER_ID_KEY, "bef730f4-d6f5-4ffb-b759-26ffa449ed7e") in result
-
-
 def test_get_conversation_pairs():
     """Test get_conversation_pairs extracts conversation information."""
     conversation = ConversationAccount(id="conversation-123")


### PR DESCRIPTION
## Summary

Reverts #118.

The ingest service only accepts GUIDs for `user.id`. Any non-GUID value gets replaced with an all-zeros GUID (`00000000-0000-0000-0000-000000000000`). Allowing non-GUID values as userId (via the `aad_object_id → agentic_user_id → frm.id` fallback chain) breaks downstream scenarios that expect an AAD object ID.

## Test plan

- [ ] Verify existing tests pass
- [ ] Confirm userId is only set from aad_object_id again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note

The original PR will not take effect since UPN (non-GUID) values are always ignored by the ingestion service.