### PR TITLE
Fix mypy error caused by requests 2.34.1 HeadersType change

### DIFF
--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -15,7 +15,7 @@ import json
 import logging
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, MutableMapping, Sequence
 from typing import Any, final
 
 import requests
@@ -227,7 +227,7 @@ class _Agent365Exporter(SpanExporter):
             return text[:max_length] + "..."
         return text
 
-    def _post_with_retries(self, url: str, body: str, headers: dict[str, str]) -> bool:
+    def _post_with_retries(self, url: str, body: str, headers: MutableMapping[str, str | bytes]) -> bool:
         for attempt in range(DEFAULT_MAX_RETRIES + 1):
             try:
                 resp = self._session.post(


### PR DESCRIPTION
## Summary

- `requests` 2.34.1 changed `HeadersType` from `Mapping[str, str | bytes]` to `MutableMapping[str, str | bytes]`, which causes mypy to reject `dict[str, str]` due to `MutableMapping`'s invariant value type parameter.
- Updated `_post_with_retries` signature to use `MutableMapping[str, str | bytes]` to match the new type.

## Test plan

- [ ] Verify mypy passes in CI (`Black, Pylint, and Mypy` job)
- [ ] Verify all pytest jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)