### PR TITLE
Pin genai util

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "opentelemetry-instrumentation-openai-v2==2.3b0",
     "opentelemetry-resource-detector-azure<1.0.0,>=0.1.5",
     "wrapt>=1.0",
-    "opentelemetry-util-genai>=0.3b0",
+    "opentelemetry-util-genai==0.3b0",
     "microsoft-agents-activity>=0.9.0",
     "microsoft-agents-hosting-core>=0.9.0",
     "aiohttp>=3.8.0",

--- a/src/microsoft/opentelemetry/_genai/_langchain/_utils.py
+++ b/src/microsoft/opentelemetry/_genai/_langchain/_utils.py
@@ -53,7 +53,7 @@ from opentelemetry.util.genai.types import (
 )
 
 try:
-    from opentelemetry.util.genai.types import ToolCallRequest as ToolCall  # >=0.4b0
+    from opentelemetry.util.genai.types import ToolCallRequest as ToolCall  # type: ignore[attr-defined]  # >=0.4b0
 except ImportError:
     from opentelemetry.util.genai.types import ToolCall  # type: ignore[no-redef,attr-defined]  # 0.3b0
 


### PR DESCRIPTION
There are breaking changes in version `"opentelemetry-util-genai==0.4b0`. We need to refactor our code before adopting that version. We will pin the version until the refactor has been done.