### PR TITLE
Add circuit breaker to A365 exporter to prevent silent telemetry loss

### DIFF
--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -46,7 +46,116 @@ DEFAULT_HTTP_TIMEOUT_SECONDS = A365_HTTP_TIMEOUT_SECONDS
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_ENDPOINT_URL = "https://agent365.svc.cloud.microsoft"
 
+# Circuit breaker defaults
+DEFAULT_CB_FAILURE_THRESHOLD = 5
+DEFAULT_CB_RECOVERY_TIMEOUT = 30.0  # seconds
+
 logger = logging.getLogger(__name__)
+
+
+class _CircuitBreaker:
+    """Lightweight circuit breaker for the A365 exporter HTTP path.
+
+    States:
+        CLOSED   – normal operation; requests flow through.
+        OPEN     – failures exceeded threshold; requests are rejected immediately.
+        HALF_OPEN – recovery window elapsed; one probe request is allowed.
+
+    Thread-safe via an internal lock.
+    """
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+    def __init__(
+        self,
+        failure_threshold: int = DEFAULT_CB_FAILURE_THRESHOLD,
+        recovery_timeout: float = DEFAULT_CB_RECOVERY_TIMEOUT,
+    ):
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._lock = threading.Lock()
+        self._state = self.CLOSED
+        self._consecutive_failures = 0
+        self._last_failure_time: float | None = None
+        self._total_rejected = 0
+        self._probe_in_flight = False
+
+    # -- query --
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            self._maybe_transition_to_half_open()
+            return self._state
+
+    @property
+    def total_rejected(self) -> int:
+        with self._lock:
+            return self._total_rejected
+
+    def allow_request(self) -> bool:
+        """Return True if a request should be attempted."""
+        with self._lock:
+            self._maybe_transition_to_half_open()
+            if self._state == self.CLOSED:
+                return True
+            if self._state == self.HALF_OPEN and not self._probe_in_flight:
+                self._probe_in_flight = True
+                return True  # allow exactly one probe
+            # OPEN or HALF_OPEN with probe already in flight
+            self._total_rejected += 1
+            return False
+
+    # -- feedback --
+
+    def record_success(self) -> None:
+        with self._lock:
+            if self._state != self.CLOSED:
+                logger.warning(
+                    "Circuit breaker CLOSED (recovered). %d requests were rejected while the circuit was open.",
+                    self._total_rejected,
+                )
+            self._state = self.CLOSED
+            self._consecutive_failures = 0
+            self._last_failure_time = None
+            self._total_rejected = 0
+            self._probe_in_flight = False
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            self._last_failure_time = time.monotonic()
+            self._probe_in_flight = False
+            if self._state == self.HALF_OPEN:
+                # Probe failed — re-open
+                self._state = self.OPEN
+                logger.warning(
+                    "Circuit breaker re-OPENED after failed probe. Will retry after %.0fs.",
+                    self._recovery_timeout,
+                )
+            elif self._state == self.CLOSED and self._consecutive_failures >= self._failure_threshold:
+                self._state = self.OPEN
+                logger.warning(
+                    "Circuit breaker OPENED after %d consecutive failures. "
+                    "Requests will be rejected for %.0fs to avoid silent telemetry loss.",
+                    self._consecutive_failures,
+                    self._recovery_timeout,
+                )
+
+    # -- internal --
+
+    def _maybe_transition_to_half_open(self) -> None:
+        """Must be called with self._lock held."""
+        if (
+            self._state == self.OPEN
+            and self._last_failure_time is not None
+            and (time.monotonic() - self._last_failure_time) >= self._recovery_timeout
+        ):
+            self._state = self.HALF_OPEN
+            self._probe_in_flight = False
+            logger.warning("Circuit breaker entering HALF_OPEN state; allowing one probe request.")
 
 
 @final
@@ -79,6 +188,7 @@ class _Agent365Exporter(SpanExporter):
         self._use_s2s_endpoint = use_s2s_endpoint
         self._max_payload_bytes = max_payload_bytes
         self._domain_override = get_validated_domain_override()
+        self._circuit_breaker = _CircuitBreaker()
 
     # ------------- SpanExporter API -----------------
 
@@ -229,6 +339,14 @@ class _Agent365Exporter(SpanExporter):
         return text
 
     def _post_with_retries(self, url: str, body: str, headers: dict[str, str | bytes]) -> bool:
+        if not self._circuit_breaker.allow_request():
+            logger.warning(
+                "Circuit breaker is OPEN \u2014 skipping POST to %s. %d total requests rejected so far.",
+                url,
+                self._circuit_breaker.total_rejected,
+            )
+            return False
+
         for attempt in range(DEFAULT_MAX_RETRIES + 1):
             try:
                 resp = self._session.post(
@@ -248,6 +366,7 @@ class _Agent365Exporter(SpanExporter):
                         correlation_id,
                         self._truncate_text(resp.text, 200),
                     )
+                    self._circuit_breaker.record_success()
                     return True
 
                 response_text = self._truncate_text(resp.text, 500)
@@ -267,6 +386,7 @@ class _Agent365Exporter(SpanExporter):
                         correlation_id,
                         response_text,
                     )
+                    self._circuit_breaker.record_failure()
                 else:
                     logger.error(
                         "HTTP %d non-retryable error. Correlation ID: %s. Response: %s. "
@@ -284,8 +404,9 @@ class _Agent365Exporter(SpanExporter):
                     time.sleep(0.5 * (2**attempt))
                     continue
                 logger.error("Request failed after %d attempts: %s", DEFAULT_MAX_RETRIES + 1, e)
+                self._circuit_breaker.record_failure()
                 return False
-        return False
+        return False  # pragma: no cover
 
     # ------------- Payload mapping ------------------
 

--- a/tests/a365/test_circuit_breaker.py
+++ b/tests/a365/test_circuit_breaker.py
@@ -1,0 +1,387 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import os
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.trace import SpanKind, StatusCode
+
+from microsoft.opentelemetry.a365.core.exporters.agent365_exporter import (
+    DEFAULT_CB_FAILURE_THRESHOLD,
+    _Agent365Exporter,
+    _CircuitBreaker,
+)
+
+# ---------------------------------------------------------------------------
+# _CircuitBreaker unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerInit(unittest.TestCase):
+    def test_starts_closed(self):
+        cb = _CircuitBreaker()
+        self.assertEqual(cb.state, _CircuitBreaker.CLOSED)
+
+    def test_custom_thresholds(self):
+        cb = _CircuitBreaker(failure_threshold=10, recovery_timeout=60.0)
+        self.assertEqual(cb.state, _CircuitBreaker.CLOSED)
+        self.assertEqual(cb.total_rejected, 0)
+
+
+class TestCircuitBreakerTransitions(unittest.TestCase):
+    def test_stays_closed_below_threshold(self):
+        cb = _CircuitBreaker(failure_threshold=5)
+        for _ in range(4):
+            cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.CLOSED)
+        self.assertTrue(cb.allow_request())
+
+    def test_opens_at_threshold(self):
+        cb = _CircuitBreaker(failure_threshold=5)
+        for _ in range(5):
+            cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.OPEN)
+        self.assertFalse(cb.allow_request())
+
+    def test_rejects_when_open(self):
+        cb = _CircuitBreaker(failure_threshold=2)
+        cb.record_failure()
+        cb.record_failure()
+        self.assertFalse(cb.allow_request())
+        self.assertFalse(cb.allow_request())
+        self.assertEqual(cb.total_rejected, 2)
+
+    def test_transitions_to_half_open_after_recovery_timeout(self):
+        cb = _CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.OPEN)
+        # Simulate recovery timeout elapsing
+        cb._last_failure_time = time.monotonic() - 31.0
+        self.assertEqual(cb.state, _CircuitBreaker.HALF_OPEN)
+        self.assertTrue(cb.allow_request())
+
+    def test_half_open_success_closes(self):
+        cb = _CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        cb._last_failure_time = time.monotonic() - 31.0
+        self.assertTrue(cb.allow_request())  # half-open allows probe
+        cb.record_success()
+        self.assertEqual(cb.state, _CircuitBreaker.CLOSED)
+        self.assertTrue(cb.allow_request())
+
+    def test_half_open_failure_reopens(self):
+        cb = _CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        cb._last_failure_time = time.monotonic() - 31.0
+        self.assertTrue(cb.allow_request())  # half-open probe
+        cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.OPEN)
+        self.assertFalse(cb.allow_request())
+
+    def test_half_open_allows_only_one_probe(self):
+        cb = _CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        cb._last_failure_time = time.monotonic() - 31.0
+        # First call gets the probe token
+        self.assertTrue(cb.allow_request())
+        # Second call should be rejected while probe is in flight
+        self.assertFalse(cb.allow_request())
+        self.assertEqual(cb.total_rejected, 1)
+
+    def test_success_resets_failure_count(self):
+        cb = _CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        # After reset, need 3 more failures to trip
+        cb.record_failure()
+        cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.CLOSED)
+        cb.record_failure()
+        self.assertEqual(cb.state, _CircuitBreaker.OPEN)
+
+    def test_total_rejected_resets_on_close(self):
+        cb = _CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        cb.allow_request()  # rejected
+        cb.allow_request()  # rejected
+        self.assertEqual(cb.total_rejected, 2)
+        cb._last_failure_time = time.monotonic() - 31.0
+        cb.allow_request()  # half-open probe allowed
+        cb.record_success()
+        self.assertEqual(cb.total_rejected, 0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _Agent365Exporter with circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def _make_span(
+    tenant_id="t1",
+    agent_id="a1",
+    name="test_span",
+    trace_id=0x1234,
+    span_id=0x5678,
+    operation_name="invoke_agent",
+):
+    span = MagicMock()
+    span.name = name
+    attrs = {
+        "microsoft.tenant.id": tenant_id,
+        "gen_ai.agent.id": agent_id,
+    }
+    if operation_name is not None:
+        attrs["gen_ai.operation.name"] = operation_name
+    span.attributes = attrs
+
+    ctx = MagicMock()
+    ctx.trace_id = trace_id
+    ctx.span_id = span_id
+    span.context = ctx
+
+    span.parent = None
+    span.kind = SpanKind.INTERNAL
+    span.start_time = 1000000000
+    span.end_time = 2000000000
+
+    status = MagicMock()
+    status.status_code = StatusCode.OK
+    status.description = ""
+    span.status = status
+
+    span.events = []
+    span.links = []
+
+    scope = MagicMock()
+    scope.name = "test_scope"
+    scope.version = "1.0"
+    span.instrumentation_scope = scope
+
+    resource = MagicMock()
+    resource.attributes = {"service.name": "test-service"}
+    span.resource = resource
+
+    return span
+
+
+class TestExporterCircuitBreakerIntegration(unittest.TestCase):
+    """Verify that _Agent365Exporter honours the circuit breaker."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def _make_exporter(self):
+        return _Agent365Exporter(token_resolver=lambda a, t: "token")
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_circuit_opens_after_consecutive_500s(self, mock_session_cls, mock_sleep):
+        """After DEFAULT_CB_FAILURE_THRESHOLD export cycles all returning 500,
+        subsequent exports should be rejected without HTTP calls."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        mock_resp.headers = {}
+
+        session_instance = MagicMock()
+        session_instance.post.return_value = mock_resp
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+
+        span = _make_span()
+
+        # Each failed export cycle = 1 circuit breaker failure
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD):
+            result = exporter.export([span])
+            self.assertEqual(result, SpanExportResult.FAILURE)
+
+        # Circuit should now be open
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.OPEN)
+
+        # Next export should fail immediately without HTTP
+        session_instance.post.reset_mock()
+        result = exporter.export([span])
+        self.assertEqual(result, SpanExportResult.FAILURE)
+        session_instance.post.assert_not_called()
+
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_circuit_recovers_after_success(self, mock_session_cls, mock_sleep):
+        """After the circuit opens and recovery timeout elapses, a successful
+        probe should close the circuit."""
+        mock_fail_resp = MagicMock()
+        mock_fail_resp.status_code = 503
+        mock_fail_resp.text = "Service Unavailable"
+        mock_fail_resp.headers = {}
+
+        mock_ok_resp = MagicMock()
+        mock_ok_resp.status_code = 200
+        mock_ok_resp.text = "OK"
+        mock_ok_resp.headers = {}
+
+        session_instance = MagicMock()
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+        exporter._circuit_breaker._recovery_timeout = 30.0
+
+        span = _make_span()
+
+        # Trip the circuit
+        session_instance.post.return_value = mock_fail_resp
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD):
+            exporter.export([span])
+
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.OPEN)
+
+        # Simulate recovery timeout elapsing by backdating _last_failure_time
+        exporter._circuit_breaker._last_failure_time = time.monotonic() - 31.0
+
+        # Next call should be a probe (half-open) — make it succeed
+        session_instance.post.return_value = mock_ok_resp
+        result = exporter.export([span])
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.CLOSED)
+
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_circuit_reopens_on_failed_probe(self, mock_session_cls, mock_sleep):
+        """If the half-open probe fails, the circuit re-opens."""
+        mock_fail_resp = MagicMock()
+        mock_fail_resp.status_code = 500
+        mock_fail_resp.text = "Error"
+        mock_fail_resp.headers = {}
+
+        session_instance = MagicMock()
+        session_instance.post.return_value = mock_fail_resp
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+        exporter._circuit_breaker._recovery_timeout = 30.0
+
+        span = _make_span()
+
+        # Trip the circuit
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD):
+            exporter.export([span])
+
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.OPEN)
+
+        # Simulate recovery timeout elapsing
+        exporter._circuit_breaker._last_failure_time = time.monotonic() - 31.0
+
+        # Probe should fail, re-opening the circuit
+        result = exporter.export([span])
+        self.assertEqual(result, SpanExportResult.FAILURE)
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.OPEN)
+
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_non_retryable_errors_do_not_trip_circuit(self, mock_session_cls, mock_sleep):
+        """Non-retryable 4xx errors (e.g. 401, 403) should not count toward
+        the circuit breaker threshold — they indicate config problems, not
+        transient endpoint failures."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = "Forbidden"
+        mock_resp.headers = {}
+
+        session_instance = MagicMock()
+        session_instance.post.return_value = mock_resp
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+
+        span = _make_span()
+
+        # Non-retryable errors should NOT trip the circuit breaker
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD + 2):
+            exporter.export([span])
+
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.CLOSED)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_network_errors_trip_circuit(self, mock_session_cls, mock_sleep):
+        """Network-level failures (RequestException) count toward the circuit breaker."""
+        import requests as req
+
+        session_instance = MagicMock()
+        session_instance.post.side_effect = req.ConnectionError("connection refused")
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+
+        span = _make_span()
+
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD):
+            exporter.export([span])
+
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.OPEN)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep")
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.requests.Session")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_success_between_failures_resets_circuit(self, mock_session_cls, mock_sleep):
+        """A successful POST mid-stream should reset the failure counter."""
+        mock_fail_resp = MagicMock()
+        mock_fail_resp.status_code = 500
+        mock_fail_resp.text = "Error"
+        mock_fail_resp.headers = {}
+
+        mock_ok_resp = MagicMock()
+        mock_ok_resp.status_code = 200
+        mock_ok_resp.text = "OK"
+        mock_ok_resp.headers = {}
+
+        session_instance = MagicMock()
+        mock_session_cls.return_value = session_instance
+
+        exporter = self._make_exporter()
+        exporter._session = session_instance
+
+        span = _make_span()
+
+        # Fail 4 times (threshold is 5)
+        session_instance.post.return_value = mock_fail_resp
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD - 1):
+            exporter.export([span])
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.CLOSED)
+
+        # Succeed once — resets counter
+        session_instance.post.return_value = mock_ok_resp
+        exporter.export([span])
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.CLOSED)
+
+        # Fail 4 more times — circuit should still be closed
+        session_instance.post.return_value = mock_fail_resp
+        for _ in range(DEFAULT_CB_FAILURE_THRESHOLD - 1):
+            exporter.export([span])
+        self.assertEqual(exporter._circuit_breaker.state, _CircuitBreaker.CLOSED)
+
+        exporter.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously, _post_with_retries retried up to 3 times per batch on 5xx/408/429 errors but had no cross-batch failure memory. When the A365 endpoint was down for an extended period, every export cycle burned ~3.5s on doomed retries while the BatchSpanProcessor queue silently dropped spans with no operator visibility.

Add a _CircuitBreaker class with three states (CLOSED, OPEN, HALF_OPEN):
- OPENS after 5 consecutive post failures (5xx, network errors, etc.)
- Fast-fails immediately when open, avoiding wasted HTTP round-trips
- Probes with a single request after 30s recovery timeout (HALF_OPEN)
- CLOSES on any successful response, resetting all counters
- Logs all state transitions at WARNING level for operator observability

This prevents queue pressure buildup and makes sustained endpoint outages visible in logs instead of silently losing telemetry.
