### PR TITLE
fix: bump agent-framework>=1.4.0 to resolve dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ langchain = [
     "langchain-core>=0.2.0",
 ]
 agent-framework = [
-    "agent-framework>=1.0.0",
+    "agent-framework>=1.4.0",
 ]
 openai-agents = [
     "openai-agents>=0.0.7",

--- a/tests/openai_agents/test_trace_instrumentor.py
+++ b/tests/openai_agents/test_trace_instrumentor.py
@@ -19,19 +19,16 @@ class TestA365OpenAIAgentsInstrumentor(unittest.TestCase):
     """Unit tests for A365OpenAIAgentsInstrumentor class."""
 
     def setUp(self):
-        # Reset singleton state between tests — must reset on the instance
-        # because BaseInstrumentor.__new__ returns the cached singleton whose
-        # instance attrs shadow class-level resets.
-        inst = A365OpenAIAgentsInstrumentor()
-        inst._processor = None
-        inst._is_instrumented_by_opentelemetry = False
+        # Clear the cached singleton first, then reset class-level attributes
+        # so the next constructor creates a fresh instance with clean defaults.
         A365OpenAIAgentsInstrumentor._instance = None
+        A365OpenAIAgentsInstrumentor._processor = None
+        A365OpenAIAgentsInstrumentor._is_instrumented_by_opentelemetry = False
 
     def tearDown(self):
-        inst = A365OpenAIAgentsInstrumentor()
-        inst._processor = None
-        inst._is_instrumented_by_opentelemetry = False
         A365OpenAIAgentsInstrumentor._instance = None
+        A365OpenAIAgentsInstrumentor._processor = None
+        A365OpenAIAgentsInstrumentor._is_instrumented_by_opentelemetry = False
 
     def test_instrumentor_initialization(self):
         instrumentor = A365OpenAIAgentsInstrumentor()

--- a/tests/openai_agents/test_trace_instrumentor.py
+++ b/tests/openai_agents/test_trace_instrumentor.py
@@ -19,13 +19,19 @@ class TestA365OpenAIAgentsInstrumentor(unittest.TestCase):
     """Unit tests for A365OpenAIAgentsInstrumentor class."""
 
     def setUp(self):
-        # Reset singleton state between tests
-        A365OpenAIAgentsInstrumentor._processor = None
-        A365OpenAIAgentsInstrumentor._is_instrumented_by_opentelemetry = False
+        # Reset singleton state between tests — must reset on the instance
+        # because BaseInstrumentor.__new__ returns the cached singleton whose
+        # instance attrs shadow class-level resets.
+        inst = A365OpenAIAgentsInstrumentor()
+        inst._processor = None
+        inst._is_instrumented_by_opentelemetry = False
+        A365OpenAIAgentsInstrumentor._instance = None
 
     def tearDown(self):
-        A365OpenAIAgentsInstrumentor._processor = None
-        A365OpenAIAgentsInstrumentor._is_instrumented_by_opentelemetry = False
+        inst = A365OpenAIAgentsInstrumentor()
+        inst._processor = None
+        inst._is_instrumented_by_opentelemetry = False
+        A365OpenAIAgentsInstrumentor._instance = None
 
     def test_instrumentor_initialization(self):
         instrumentor = A365OpenAIAgentsInstrumentor()


### PR DESCRIPTION
agent-framework 1.0.0 pins agent-framework-core==1.0.0 which conflicts with agent-framework-durabletask requiring agent-framework-core>=1.4.0.

Also fix singleton test isolation in openai_agents test.