### PR TITLE
perf: Add pytest-benchmark suite and PR regression gate

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -106,7 +106,11 @@ jobs:
             report.md
 
       - name: Post sticky PR comment
-        if: always() && github.event_name == 'pull_request'
+        # Skip for PRs from forks — the default GITHUB_TOKEN has read-only
+        # access in that case and the comment API will reject the call. The
+        # JSON artifacts and the workflow log still contain the comparison.
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: perf-comparison

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -68,7 +68,6 @@ jobs:
         working-directory: base
         run: |
           python -m pip install --force-reinstall --no-deps .
-          python -m pip install .
           python -m pip install "pytest>=8.0" "pytest-benchmark>=4.0"
 
       - name: Run baseline benchmarks

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,119 @@
+name: Performance
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: perf-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark distro overhead
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      PERF_REGRESSION_THRESHOLD: "15"
+
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+        with:
+          path: pr
+          fetch-depth: 0
+
+      - name: Check out base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          path: base
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # ------------------------------------------------------------------
+      # Candidate (PR) run
+      # ------------------------------------------------------------------
+      - name: Install candidate (PR) distro
+        working-directory: pr
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+          python -m pip install "pytest>=8.0" "pytest-benchmark>=4.0"
+
+      - name: Run candidate benchmarks
+        working-directory: pr
+        run: |
+          python -m pytest tests/perf \
+            --benchmark-only \
+            --benchmark-min-rounds=5 \
+            --benchmark-warmup=on \
+            --benchmark-json="$GITHUB_WORKSPACE/pr.json"
+
+      # ------------------------------------------------------------------
+      # Baseline (base branch) run.
+      # We always invoke the PR copy of the perf tests (tests/perf may not
+      # exist on base) but install the *base* distro into the same env first
+      # so the `microsoft.opentelemetry` import resolves to baseline code.
+      # ------------------------------------------------------------------
+      - name: Install baseline distro
+        working-directory: base
+        run: |
+          python -m pip install --force-reinstall --no-deps .
+          python -m pip install .
+          python -m pip install "pytest>=8.0" "pytest-benchmark>=4.0"
+
+      - name: Run baseline benchmarks
+        working-directory: pr
+        run: |
+          python -m pytest tests/perf \
+            --benchmark-only \
+            --benchmark-min-rounds=5 \
+            --benchmark-warmup=on \
+            --benchmark-json="$GITHUB_WORKSPACE/base.json"
+
+      # ------------------------------------------------------------------
+      # Compare + report
+      # ------------------------------------------------------------------
+      - name: Compare results
+        id: compare
+        working-directory: pr
+        run: |
+          set +e
+          python -m perf.compare \
+            --baseline "$GITHUB_WORKSPACE/base.json" \
+            --candidate "$GITHUB_WORKSPACE/pr.json" \
+            --threshold "$PERF_REGRESSION_THRESHOLD" \
+            --output "$GITHUB_WORKSPACE/report.md"
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results
+          path: |
+            pr.json
+            base.json
+            report.md
+
+      - name: Post sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: perf-comparison
+          path: report.md
+
+      - name: Fail on regression
+        if: steps.compare.outputs.exit_code != '0'
+        run: |
+          echo "Gating perf scenario regressed beyond ${PERF_REGRESSION_THRESHOLD}%"
+          exit 1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,7 @@
 pytest>=8.0
 pytest-asyncio>=0.23.0
 pytest-cov>=5.0
+pytest-benchmark>=4.0
 black>=24.0
 microsoft-agents-activity
 microsoft-agents-hosting-core

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,51 @@
+# Performance benchmarks
+
+This directory contains the regression-gating glue used by the `performance`
+CI workflow. The benchmarks themselves live in
+[`tests/perf/test_overhead.py`](../tests/perf/test_overhead.py) and are
+driven by [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/).
+
+## Scenarios
+
+| Test | Gating | What it measures |
+| --- | --- | --- |
+| `test_azure_monitor_span` | yes | `configure_azure_monitor` + `tracer.start_as_current_span` |
+| `test_azure_monitor_log`  | yes | `configure_azure_monitor` + `logger.info` |
+| `test_otel_span`          | no  | Plain `opentelemetry-sdk` `TracerProvider` reference |
+| `test_otel_log`           | no  | Plain `opentelemetry-sdk` `LoggerProvider` reference |
+
+Non-gating scenarios are informational only — they show how much overhead
+the distro adds on top of upstream and never fail CI.
+
+The gating flag is attached to each benchmark via
+`benchmark.extra_info["gating"]` so `perf/compare.py` can pick it up out of
+the pytest-benchmark JSON.
+
+## Running locally
+
+From the repo root, with the distro and dev deps installed
+(`pip install -e . && pip install -r dev_requirements.txt`):
+
+```bash
+# Run the benchmarks and save the result.
+pytest tests/perf --benchmark-only --benchmark-json=pr.json
+
+# Compare against a previously-saved baseline (e.g. from main).
+python -m perf.compare --baseline base.json --candidate pr.json --threshold 15
+```
+
+`pytest --benchmark-skip` is the default (see `pyproject.toml`), so a normal
+`pytest` invocation will *skip* the perf tests entirely. Pass
+`--benchmark-only` to opt in.
+
+## CI
+
+`.github/workflows/performance.yml` runs the suite on every pull request:
+
+1. Install the PR branch, run `pytest tests/perf --benchmark-only
+   --benchmark-json=pr.json`.
+2. Check out the base branch, install it, repeat → `base.json`.
+3. `perf/compare.py` produces a markdown report and exits non-zero if any
+   *gating* scenario regresses by more than `PERF_REGRESSION_THRESHOLD`
+   percent (default 15).
+4. The report is posted as a sticky PR comment.

--- a/perf/compare.py
+++ b/perf/compare.py
@@ -87,7 +87,9 @@ def main(argv: list[str] | None = None) -> int:
     for name in all_names:
         b = base.get(name)
         c = cand.get(name)
-        gating = bool(((c or b or {}).get("extra_info") or {}).get("gating", False))
+        b_gating = bool(((b or {}).get("extra_info") or {}).get("gating", False))
+        c_gating = bool(((c or {}).get("extra_info") or {}).get("gating", False))
+        gating = b_gating or c_gating
         b_sec = _stats_seconds(b)
         c_sec = _stats_seconds(c)
         b_ops = _ops_per_sec(b_sec)

--- a/perf/compare.py
+++ b/perf/compare.py
@@ -1,0 +1,125 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Compare two pytest-benchmark JSON files and gate on regression.
+
+Reads the JSON produced by ``pytest --benchmark-json=...`` for the base
+branch and the PR branch. A scenario "regresses" when its candidate median
+operation time is greater than the baseline median by more than
+``--threshold`` percent (i.e. slower).
+
+Emits a markdown comparison table on stdout (suitable for posting as a
+sticky PR comment). Exits with status ``1`` if any *gating* scenario
+regresses past the threshold; non-gating scenarios are reported but never
+fail the build.
+
+A scenario is treated as gating when its ``extra_info.gating`` field is
+``true`` in either file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, Optional
+
+
+def _load_benchmarks(path: str) -> Dict[str, Dict[str, Any]]:
+    with open(path, "r", encoding="utf-8") as f:
+        doc = json.load(f)
+    out: Dict[str, Dict[str, Any]] = {}
+    for entry in doc.get("benchmarks", []):
+        # Strip the conventional ``test_`` prefix so report names match the
+        # scenario names used in PR comments.
+        name = entry.get("name", "")
+        if name.startswith("test_"):
+            name = name[len("test_") :]
+        out[name] = entry
+    return out
+
+
+def _stats_seconds(entry: Optional[Dict[str, Any]]) -> Optional[float]:
+    if not entry:
+        return None
+    return entry.get("stats", {}).get("median")
+
+
+def _ops_per_sec(seconds: Optional[float]) -> float:
+    if not seconds or seconds <= 0:
+        return float("nan")
+    return 1.0 / seconds
+
+
+def _pct_slower(base_s: float, cand_s: float) -> float:
+    """Positive number => candidate is slower than baseline (regression)."""
+    if base_s <= 0:
+        return 0.0
+    return (cand_s - base_s) / base_s * 100.0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare two pytest-benchmark JSON files and gate on regression.")
+    parser.add_argument("--baseline", required=True, help="pytest-benchmark JSON for the base branch")
+    parser.add_argument("--candidate", required=True, help="pytest-benchmark JSON for the PR branch")
+    parser.add_argument("--threshold", type=float, default=15.0, help="Max allowed regression %% (default 15)")
+    parser.add_argument("--output", help="Write markdown report to this path in addition to stdout")
+    args = parser.parse_args(argv)
+
+    base = _load_benchmarks(args.baseline)
+    cand = _load_benchmarks(args.candidate)
+    all_names = sorted(set(base) | set(cand))
+
+    lines: list[str] = []
+    lines.append("### Performance comparison")
+    lines.append("")
+    lines.append(
+        f"Threshold: regressions >{args.threshold:.1f}% on gating scenarios fail the build. "
+        "Higher ops/s is better; positive Δ means the PR is slower."
+    )
+    lines.append("")
+    lines.append("| Scenario | Gating | Baseline (ops/s) | Candidate (ops/s) | Δ % | Status |")
+    lines.append("| --- | --- | ---: | ---: | ---: | :---: |")
+
+    any_regression = False
+    for name in all_names:
+        b = base.get(name)
+        c = cand.get(name)
+        gating = bool(((c or b or {}).get("extra_info") or {}).get("gating", False))
+        b_sec = _stats_seconds(b)
+        c_sec = _stats_seconds(c)
+        b_ops = _ops_per_sec(b_sec)
+        c_ops = _ops_per_sec(c_sec)
+        if b_sec is not None and c_sec is not None:
+            delta = _pct_slower(b_sec, c_sec)
+            regressed = gating and delta > args.threshold
+            status = "❌" if regressed else ("⚠️" if delta > args.threshold else "✅")
+            if regressed:
+                any_regression = True
+            lines.append(
+                f"| `{name}` | {'yes' if gating else 'no'} | {b_ops:,.1f} | {c_ops:,.1f} | "
+                f"{delta:+.2f}% | {status} |"
+            )
+        else:
+            lines.append(
+                f"| `{name}` | {'yes' if gating else 'no'} | "
+                f"{('—' if b_sec is None else f'{b_ops:,.1f}')} | "
+                f"{('—' if c_sec is None else f'{c_ops:,.1f}')} | — | ➖ |"
+            )
+
+    report = "\n".join(lines) + "\n"
+    sys.stdout.write(report)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(report)
+
+    if any_regression:
+        sys.stderr.write(f"\n[compare] FAIL: one or more gating scenarios regressed > {args.threshold:.1f}%\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ hosting = [
 test = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-benchmark>=4.0",
 ]
 dev = [
     "black>=24.0",
@@ -72,6 +73,7 @@ dev = [
     "pyright>=1.1",
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-benchmark>=4.0",
 ]
 docs = [
     "sphinx>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,6 @@ disable = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Skip pytest-benchmark tests by default; the perf workflow opts in with
+# --benchmark-only.
+addopts = "--benchmark-skip"

--- a/tests/perf/test_overhead.py
+++ b/tests/perf/test_overhead.py
@@ -1,0 +1,150 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""Performance benchmarks for the Microsoft OpenTelemetry distro.
+
+These tests are skipped by default — they only execute when pytest is invoked
+with ``--benchmark-only`` (or any other ``--benchmark-*`` flag) by the
+performance CI workflow.
+
+Two pairs of scenarios are measured:
+
+* ``azure_monitor_span`` / ``azure_monitor_log`` (gating): the per-operation
+  cost the distro adds on top of upstream OpenTelemetry.
+* ``otel_span`` / ``otel_log`` (informational): a plain upstream
+  ``opentelemetry-sdk`` reference. They are reported but never fail the
+  build.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+_FAKE_CONNECTION_STRING = (
+    "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+    "IngestionEndpoint=https://localhost/;"
+    "LiveEndpoint=https://localhost/"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def _azure_monitor_configured() -> None:
+    """Call ``configure_azure_monitor`` once per pytest session with all
+    network-facing features disabled so the benchmark measures only the
+    in-process hot path."""
+    from microsoft.opentelemetry._azure_monitor._configure import configure_azure_monitor
+
+    configure_azure_monitor(
+        connection_string=_FAKE_CONNECTION_STRING,
+        disable_metrics=True,
+        enable_live_metrics=False,
+        enable_performance_counters=False,
+        disable_offline_storage=True,
+    )
+
+
+@pytest.fixture
+def azure_monitor_tracer(_azure_monitor_configured):
+    from opentelemetry import trace
+
+    return trace.get_tracer("perf.azure_monitor_span")
+
+
+@pytest.fixture
+def azure_monitor_logger(_azure_monitor_configured):
+    logger = logging.getLogger("perf.azure_monitor_log")
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+@pytest.fixture
+def otel_tracer():
+    # Build our own provider rather than touching the global TracerProvider so
+    # this reference benchmark is insulated from `configure_azure_monitor`
+    # being called by other tests in the same session.
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    provider = TracerProvider()
+    provider.add_span_processor(BatchSpanProcessor(InMemorySpanExporter()))
+    return provider.get_tracer("perf.otel_span")
+
+
+@pytest.fixture
+def otel_logger():
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, InMemoryLogExporter
+
+    provider = LoggerProvider()
+    provider.add_log_record_processor(BatchLogRecordProcessor(InMemoryLogExporter()))
+    handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
+    logger = logging.getLogger("perf.otel_log")
+    logger.setLevel(logging.INFO)
+    if not any(isinstance(h, LoggingHandler) for h in logger.handlers):
+        logger.addHandler(handler)
+    return logger
+
+
+def _mark_gating(benchmark, gating: bool) -> None:
+    benchmark.extra_info["gating"] = gating
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="span")
+def test_azure_monitor_span(benchmark, azure_monitor_tracer):
+    _mark_gating(benchmark, True)
+    tracer = azure_monitor_tracer
+
+    def _op() -> None:
+        with tracer.start_as_current_span("bench") as span:
+            span.set_attribute("bench.attr", 1)
+
+    benchmark(_op)
+
+
+@pytest.mark.benchmark(group="log")
+def test_azure_monitor_log(benchmark, azure_monitor_logger):
+    _mark_gating(benchmark, True)
+    logger = azure_monitor_logger
+
+    def _op() -> None:
+        logger.info("bench message %s", 1)
+
+    benchmark(_op)
+
+
+@pytest.mark.benchmark(group="span")
+def test_otel_span(benchmark, otel_tracer):
+    _mark_gating(benchmark, False)
+    tracer = otel_tracer
+
+    def _op() -> None:
+        with tracer.start_as_current_span("bench") as span:
+            span.set_attribute("bench.attr", 1)
+
+    benchmark(_op)
+
+
+@pytest.mark.benchmark(group="log")
+def test_otel_log(benchmark, otel_logger):
+    _mark_gating(benchmark, False)
+    logger = otel_logger
+
+    def _op() -> None:
+        logger.info("bench message %s", 1)
+
+    benchmark(_op)

--- a/tests/perf/test_overhead.py
+++ b/tests/perf/test_overhead.py
@@ -33,6 +33,9 @@ _FAKE_CONNECTION_STRING = (
     "LiveEndpoint=https://localhost/"
 )
 
+_AZURE_MONITOR_LOGGER_NAME = "perf.azure_monitor_log"
+_OTEL_LOGGER_NAME = "perf.otel_log"
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -52,6 +55,7 @@ def _azure_monitor_configured() -> None:
         enable_live_metrics=False,
         enable_performance_counters=False,
         disable_offline_storage=True,
+        logger_name=_AZURE_MONITOR_LOGGER_NAME,
     )
 
 
@@ -64,8 +68,11 @@ def azure_monitor_tracer(_azure_monitor_configured):
 
 @pytest.fixture
 def azure_monitor_logger(_azure_monitor_configured):
-    logger = logging.getLogger("perf.azure_monitor_log")
+    logger = logging.getLogger(_AZURE_MONITOR_LOGGER_NAME)
     logger.setLevel(logging.INFO)
+    # Don't let records propagate to the root logger, which may have handlers
+    # installed by other tests in the session.
+    logger.propagate = False
     return logger
 
 
@@ -91,8 +98,12 @@ def otel_logger():
     provider = LoggerProvider()
     provider.add_log_record_processor(BatchLogRecordProcessor(InMemoryLogExporter()))
     handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
-    logger = logging.getLogger("perf.otel_log")
+    logger = logging.getLogger(_OTEL_LOGGER_NAME)
     logger.setLevel(logging.INFO)
+    # Isolate from any handlers attached to ancestor loggers (e.g. the root
+    # logger if Azure Monitor was configured earlier in the session) so this
+    # reference benchmark measures only the local handler/provider.
+    logger.propagate = False
     if not any(isinstance(h, LoggingHandler) for h in logger.handlers):
         logger.addHandler(handler)
     return logger

--- a/tests/perf/test_overhead.py
+++ b/tests/perf/test_overhead.py
@@ -18,6 +18,9 @@ Two pairs of scenarios are measured:
   build.
 """
 
+# pylint: disable=redefined-outer-name
+# (pytest fixtures shadow the fixture function name by design.)
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
Adds a pytest-benchmark perf suite plus a CI workflow that gates PRs against perf regressions, inspired by microsoft/ApplicationInsights-node.js#1500. No telemetry is shipped anywhere (no Geneva); the gate is purely a PR check.

## Scenarios (`tests/perf/test_overhead.py`)

| Test | Gating | What it measures |
| --- | :---: | --- |
| `test_azure_monitor_span` | yes | `configure_azure_monitor` + `tracer.start_as_current_span` |
| `test_azure_monitor_log`  | yes | `configure_azure_monitor` + `logger.info` |
| `test_otel_span`          | no  | Plain `opentelemetry-sdk` `TracerProvider` reference |
| `test_otel_log`           | no  | Plain `opentelemetry-sdk` `LoggerProvider` reference |

The Azure-Monitor pair shares a session-scoped fixture that calls `configure_azure_monitor` once with all network-facing features disabled (live metrics, perf counters, offline storage). The OTel pair builds its own `TracerProvider` / `LoggerProvider` directly so it isn't perturbed by the global mutation. Non-gating scenarios are reported but never fail CI.

## Skipped by default

`pyproject.toml` sets `addopts = "--benchmark-skip"` so a normal `pytest` invocation skips the perf tests entirely. The perf workflow opts in with `--benchmark-only`.

## CI (`.github/workflows/performance.yml`)

1. Install the PR distro, run `pytest tests/perf --benchmark-only --benchmark-json=pr.json`.
2. Check out the base branch, install it, repeat → `base.json`.
3. `perf/compare.py` produces a markdown report and exits non-zero if any **gating** scenario regresses by more than `PERF_REGRESSION_THRESHOLD` percent (default 15).
4. Sticky PR comment via `marocchino/sticky-pull-request-comment@v2`; JSON + report uploaded as artifacts.

## Local usage

```
pip install -e . && pip install -r dev_requirements.txt
pytest tests/perf --benchmark-only --benchmark-json=pr.json
python -m perf.compare --baseline base.json --candidate pr.json --threshold 15
```

## Verified locally

- `pytest tests/perf --benchmark-only` runs all 4 benchmarks and writes a valid JSON.
- `perf/compare.py` exits **0** on equal results and **1** when a gating scenario's median is doubled.
- `pytest tests/perf` with no flags reports `4 skipped` — confirms the default-skip works.
