### PR TITLE
fix: use get_span_context() instead of .context to support NonRecordingSpan

### DIFF
--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -460,7 +460,7 @@ class _Agent365Exporter(SpanExporter):
         }
 
     def _map_span(self, sp: ReadableSpan) -> dict[str, Any]:
-        ctx = sp.context
+        ctx = sp.get_span_context()
 
         parent_span_id = None
         if sp.parent is not None and sp.parent.span_id != 0:

--- a/src/microsoft/opentelemetry/a365/core/exporters/enriched_span.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/enriched_span.py
@@ -55,7 +55,7 @@ class EnrichedReadableSpan(ReadableSpan):
 
     @property
     def context(self):  # type: ignore[override]
-        return self._span.context
+        return self._span.get_span_context()
 
     @property
     def parent(self):  # type: ignore[override]

--- a/src/microsoft/opentelemetry/a365/core/opentelemetry_scope.py
+++ b/src/microsoft/opentelemetry/a365/core/opentelemetry_scope.py
@@ -163,7 +163,8 @@ class OpenTelemetryScope:
 
             # Log span creation
             if self._span:
-                span_id = f"{self._span.context.span_id:016x}" if self._span.context else "unknown"
+                sc = self._span.get_span_context()
+                span_id = f"{sc.span_id:016x}" if sc else "unknown"
                 logger.info("Span started: '%s' (%s)", activity_name, span_id)
             else:
                 logger.error("Failed to create span: '%s' - tracer returned None", activity_name)
@@ -269,8 +270,10 @@ class OpenTelemetryScope:
         """End the span and record metrics."""
         if self._span and self._is_telemetry_enabled() and not self._has_ended:
             self._has_ended = True
-            span_id = f"{self._span.context.span_id:016x}" if self._span.context else "unknown"
-            logger.info("Span ended: '%s' (%s)", self._span.name, span_id)
+            sc = self._span.get_span_context()
+            span_id = f"{sc.span_id:016x}" if sc else "unknown"
+            span_name = getattr(self._span, "name", "unknown")
+            logger.info("Span ended: '%s' (%s)", span_name, span_id)
 
             # Convert custom end time to OTel-compatible format (nanoseconds since epoch)
             otel_end_time = self._datetime_to_ns(self._custom_end_time)

--- a/tests/a365/test_circuit_breaker.py
+++ b/tests/a365/test_circuit_breaker.py
@@ -142,6 +142,7 @@ def _make_span(
     ctx.trace_id = trace_id
     ctx.span_id = span_id
     span.context = ctx
+    span.get_span_context.return_value = ctx
 
     span.parent = None
     span.kind = SpanKind.INTERNAL

--- a/tests/a365/test_exporter.py
+++ b/tests/a365/test_exporter.py
@@ -35,6 +35,7 @@ def _make_span(
     ctx.trace_id = trace_id
     ctx.span_id = span_id
     span.context = ctx
+    span.get_span_context.return_value = ctx
 
     span.parent = None
     span.kind = SpanKind.INTERNAL

--- a/tests/a365/test_nonrecording_span.py
+++ b/tests/a365/test_nonrecording_span.py
@@ -1,0 +1,193 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests that A365 observability code handles NonRecordingSpan gracefully.
+
+When the TracerProvider has no valid exporter (e.g. token resolver returns
+None on the first turn), it produces NonRecordingSpan instances. These only
+expose get_span_context() — the .context attribute does not exist. The code
+must use get_span_context() everywhere to avoid AttributeError crashes.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from microsoft.opentelemetry.a365.core.exporters.enriched_span import (
+    EnrichedReadableSpan,
+)
+from microsoft.opentelemetry.a365.core.opentelemetry_scope import (
+    OpenTelemetryScope,
+)
+
+
+def _make_non_recording_span(trace_id=0, span_id=0):
+    """Create a NonRecordingSpan with the given trace/span IDs."""
+    return NonRecordingSpan(
+        SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(0),
+        )
+    )
+
+
+class TestOpenTelemetryScopeNonRecordingSpan(unittest.TestCase):
+    """Verify OpenTelemetryScope works when the tracer returns a NonRecordingSpan."""
+
+    @patch.dict(os.environ, {"ENABLE_OBSERVABILITY": "true"})
+    @patch.object(OpenTelemetryScope, "_get_tracer")
+    def test_init_with_non_recording_span(self, mock_get_tracer):
+        """__init__ must not crash when tracer.start_span returns NonRecordingSpan."""
+        mock_tracer = MagicMock()
+        nr_span = _make_non_recording_span(trace_id=0xABCD, span_id=0x1234)
+        mock_tracer.start_span.return_value = nr_span
+        mock_get_tracer.return_value = mock_tracer
+
+        # Should not raise AttributeError
+        scope = OpenTelemetryScope(
+            operation_name="invoke_agent",
+            activity_name="test_activity",
+        )
+
+        self.assertIs(scope._span, nr_span)
+
+    @patch.dict(os.environ, {"ENABLE_OBSERVABILITY": "true"})
+    @patch.object(OpenTelemetryScope, "_get_tracer")
+    def test_end_with_non_recording_span(self, mock_get_tracer):
+        """_end() must not crash when the span is a NonRecordingSpan."""
+        mock_tracer = MagicMock()
+        nr_span = _make_non_recording_span(trace_id=0xABCD, span_id=0x1234)
+        mock_tracer.start_span.return_value = nr_span
+        mock_get_tracer.return_value = mock_tracer
+
+        scope = OpenTelemetryScope(
+            operation_name="invoke_agent",
+            activity_name="test_activity",
+        )
+
+        # Should not raise AttributeError
+        scope._end()
+
+    @patch.dict(os.environ, {"ENABLE_OBSERVABILITY": "true"})
+    @patch.object(OpenTelemetryScope, "_get_tracer")
+    def test_dispose_with_non_recording_span(self, mock_get_tracer):
+        """Full dispose lifecycle must not crash with NonRecordingSpan."""
+        mock_tracer = MagicMock()
+        nr_span = _make_non_recording_span(trace_id=0xABCD, span_id=0x1234)
+        mock_tracer.start_span.return_value = nr_span
+        mock_get_tracer.return_value = mock_tracer
+
+        scope = OpenTelemetryScope(
+            operation_name="invoke_agent",
+            activity_name="test_activity",
+        )
+
+        # Context manager exit should not raise
+        scope.__exit__(None, None, None)
+
+
+class TestEnrichedReadableSpanNonRecordingSpan(unittest.TestCase):
+    """Verify EnrichedReadableSpan delegates context via get_span_context()."""
+
+    def test_context_property_uses_get_span_context(self):
+        """EnrichedReadableSpan.context must call get_span_context(), not .context."""
+        mock_span = MagicMock()
+        expected_ctx = SpanContext(
+            trace_id=0xFF,
+            span_id=0xAA,
+            is_remote=False,
+            trace_flags=TraceFlags(0),
+        )
+        mock_span.get_span_context.return_value = expected_ctx
+        # Ensure .context attribute is NOT used
+        del mock_span.context
+
+        enriched = EnrichedReadableSpan(mock_span, extra_attributes={"key": "val"})
+
+        result = enriched.context
+        self.assertIs(result, expected_ctx)
+        mock_span.get_span_context.assert_called_once()
+
+    def test_to_json_with_non_recording_span_context(self):
+        """to_json() must not crash when wrapped span uses get_span_context()."""
+        mock_span = MagicMock()
+        mock_span.name = "test"
+        mock_span.get_span_context.return_value = SpanContext(
+            trace_id=0x1234,
+            span_id=0x5678,
+            is_remote=False,
+            trace_flags=TraceFlags(0),
+        )
+        del mock_span.context
+        mock_span.attributes = {"key": "value"}
+        mock_span.kind = "INTERNAL"
+        mock_span.parent = None
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.status = None
+        mock_span.events = []
+        mock_span.links = []
+        mock_span.resource = None
+
+        enriched = EnrichedReadableSpan(mock_span, extra_attributes={})
+
+        # Should not raise
+        json_str = enriched.to_json()
+        self.assertIn("test", json_str)
+        self.assertIn("0x00000000000000000000000000001234", json_str)
+
+
+class TestAgent365ExporterMapSpanGetSpanContext(unittest.TestCase):
+    """Verify _map_span uses get_span_context() instead of .context."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_map_span_calls_get_span_context(self):
+        """_map_span must use get_span_context(), not .context attribute."""
+        from microsoft.opentelemetry.a365.core.exporters.agent365_exporter import (
+            _Agent365Exporter,
+        )
+
+        exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+
+        span = MagicMock()
+        span.name = "test_span"
+        span.attributes = {"gen_ai.operation.name": "invoke_agent"}
+
+        expected_ctx = SpanContext(
+            trace_id=0xABCD,
+            span_id=0x1234,
+            is_remote=False,
+            trace_flags=TraceFlags(0),
+        )
+        span.get_span_context.return_value = expected_ctx
+        # Remove .context so it would fail if accessed
+        del span.context
+
+        span.parent = None
+        span.kind = MagicMock()
+        span.start_time = 1000000000
+        span.end_time = 2000000000
+        span.status = MagicMock()
+        span.status.status_code = MagicMock()
+        span.status.description = ""
+        span.events = []
+        span.links = []
+        span.instrumentation_scope = MagicMock()
+        span.instrumentation_scope.name = "test"
+        span.instrumentation_scope.version = "1.0"
+
+        # Should not raise AttributeError
+        mapped = exporter._map_span(span)
+
+        span.get_span_context.assert_called_once()
+        self.assertIn("traceId", mapped)
+        self.assertIn("spanId", mapped)
+        exporter.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/a365/test_nonrecording_span.py
+++ b/tests/a365/test_nonrecording_span.py
@@ -95,26 +95,44 @@ class TestEnrichedReadableSpanNonRecordingSpan(unittest.TestCase):
 
     def test_context_property_uses_get_span_context(self):
         """EnrichedReadableSpan.context must call get_span_context(), not .context."""
-        mock_span = MagicMock()
         expected_ctx = SpanContext(
             trace_id=0xFF,
             span_id=0xAA,
             is_remote=False,
             trace_flags=TraceFlags(0),
         )
+        mock_span = MagicMock(
+            spec_set=["get_span_context", "attributes", "name"],
+        )
         mock_span.get_span_context.return_value = expected_ctx
-        # Ensure .context attribute is NOT used
-        del mock_span.context
 
         enriched = EnrichedReadableSpan(mock_span, extra_attributes={"key": "val"})
 
         result = enriched.context
         self.assertIs(result, expected_ctx)
         mock_span.get_span_context.assert_called_once()
+        # Verify .context would fail on the mock (proving we don't use it)
+        with self.assertRaises(AttributeError):
+            _ = mock_span.context
 
     def test_to_json_with_non_recording_span_context(self):
         """to_json() must not crash when wrapped span uses get_span_context()."""
-        mock_span = MagicMock()
+        mock_span = MagicMock(
+            spec_set=[
+                "get_span_context",
+                "name",
+                "attributes",
+                "kind",
+                "parent",
+                "start_time",
+                "end_time",
+                "status",
+                "events",
+                "links",
+                "resource",
+                "instrumentation_scope",
+            ],
+        )
         mock_span.name = "test"
         mock_span.get_span_context.return_value = SpanContext(
             trace_id=0x1234,
@@ -122,7 +140,6 @@ class TestEnrichedReadableSpanNonRecordingSpan(unittest.TestCase):
             is_remote=False,
             trace_flags=TraceFlags(0),
         )
-        del mock_span.context
         mock_span.attributes = {"key": "value"}
         mock_span.kind = "INTERNAL"
         mock_span.parent = None
@@ -153,7 +170,21 @@ class TestAgent365ExporterMapSpanGetSpanContext(unittest.TestCase):
 
         exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
 
-        span = MagicMock()
+        span = MagicMock(
+            spec_set=[
+                "get_span_context",
+                "name",
+                "attributes",
+                "parent",
+                "kind",
+                "start_time",
+                "end_time",
+                "status",
+                "events",
+                "links",
+                "instrumentation_scope",
+            ],
+        )
         span.name = "test_span"
         span.attributes = {"gen_ai.operation.name": "invoke_agent"}
 
@@ -164,8 +195,6 @@ class TestAgent365ExporterMapSpanGetSpanContext(unittest.TestCase):
             trace_flags=TraceFlags(0),
         )
         span.get_span_context.return_value = expected_ctx
-        # Remove .context so it would fail if accessed
-        del span.context
 
         span.parent = None
         span.kind = MagicMock()

--- a/tests/a365/test_payload_chunking.py
+++ b/tests/a365/test_payload_chunking.py
@@ -149,6 +149,7 @@ class TestExporterChunking(unittest.TestCase):
         ctx.trace_id = 0x1
         ctx.span_id = span_id
         mock_span.context = ctx
+        mock_span.get_span_context.return_value = ctx
         mock_span.parent = None
         mock_span.start_time = 1640995200000000000
         mock_span.end_time = 1640995260000000000


### PR DESCRIPTION
Fixes #166 

When the token resolver returns None on the first turn, the TracerProvider produces a NonRecordingSpan. The .context attribute only exists on concrete ReadableSpan implementations, causing AttributeError crashes on the first agent message.

Replace all span.context accesses with the public get_span_context() interface method, which is available on all Span types including NonRecordingSpan. Also guard the .name access in _end() with getattr() since NonRecordingSpan lacks that attribute as well.

Changes:
- opentelemetry_scope.py: use get_span_context() in span start/end logging
- enriched_span.py: delegate context property via get_span_context()
- agent365_exporter.py: use get_span_context() in _map_span()
- Update test mocks to set get_span_context() return value
- Add test_nonrecording_span.py with 6 targeted tests