### PR TITLE
Fix enable_sensitive_data leaking to all instrumentors

### DIFF
--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -712,6 +712,7 @@ def _get_instrumentation_kwargs(otel_kwargs: Dict[str, Any], lib_name: str) -> D
 def _setup_instrumentations(otel_kwargs: Dict[str, Any], **kwargs: Any) -> None:
     """Discover and activate OTel instrumentations for supported libraries."""
     enable_a365: bool = kwargs.pop("enable_a365", False)
+    enable_sensitive_data: bool = kwargs.pop(ENABLE_SENSITIVE_DATA_ARG, False)
     _disable_openai_v2_instrumentation(otel_kwargs)
     entry_point_finder = _EntryPointDistFinder()
     for entry_point in entry_points(group="opentelemetry_instrumentor"):
@@ -739,6 +740,8 @@ def _setup_instrumentations(otel_kwargs: Dict[str, Any], **kwargs: Any) -> None:
                 continue
             lib_kwargs = _get_instrumentation_kwargs(otel_kwargs, lib_name)
             merged_kwargs = {**kwargs, **lib_kwargs}
+            if lib_name == "agent_framework":
+                merged_kwargs[ENABLE_SENSITIVE_DATA_ARG] = enable_sensitive_data
             instrumentor: Any = entry_point.load()
             instrumentor().instrument(skip_dep_check=True, **merged_kwargs)
             set_sdkstats_instrumentation_by_name(lib_name)

--- a/tests/test_instrumentation_options.py
+++ b/tests/test_instrumentation_options.py
@@ -129,20 +129,20 @@ class TestInstrumentationKwargsForwarding(unittest.TestCase):
         self.assertEqual(call_kwargs["request_hook"], "my_hook")
         self.assertNotIn("enabled", call_kwargs)
 
-    @patch("microsoft.opentelemetry._distro._SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_lib",))
+    @patch("microsoft.opentelemetry._distro._SUPPORTED_INSTRUMENTED_LIBRARIES", ("agent_framework",))
     @patch("microsoft.opentelemetry._distro._is_instrumentation_enabled", return_value=True)
     @patch("microsoft.opentelemetry._distro.get_dist_dependency_conflicts", return_value=None)
     @patch("microsoft.opentelemetry._distro.entry_points")
     def test_shared_kwargs_merged_with_per_lib(self, ep_iter_mock, _dep, _enabled):
         ep_mock = MagicMock()
-        ep_mock.name = "test_lib"
+        ep_mock.name = "agent_framework"
         instrumentor_instance = MagicMock()
         ep_mock.load.return_value = lambda: instrumentor_instance
         ep_iter_mock.return_value = [ep_mock]
 
         otel_kwargs = {
             "instrumentation_options": {
-                "test_lib": {"agent_id": "bot-1"},
+                "agent_framework": {"agent_id": "bot-1"},
             }
         }
         _setup_instrumentations(otel_kwargs, enable_sensitive_data=True)


### PR DESCRIPTION
The enable_sensitive_data kwarg was passed to every instrumentor via shared kwargs, but only agent_framework understands it. Upstream instrumentors like FastAPIInstrumentor reject the unknown keyword argument, causing TypeError at startup.

Pop enable_sensitive_data from shared kwargs (like enable_a365 already was) and only inject it when the instrumentor is agent_framework.