### PR TITLE
ci: add wheel build and artifact upload to PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -93,10 +93,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Detect minimum Python version
+        id: python-version
+        run: |
+          version=$(python3 -c "
+          import tomllib, re
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          req = data['project']['requires-python']
+          print(re.search(r'[\d.]+', req).group())
+          ")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.python-version.outputs.version }}
 
       - name: Install build
         run: python -m pip install --upgrade pip build

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -85,6 +85,31 @@ jobs:
       - name: Run tests
         run: tox -e ${{ matrix.tox-env }}
 
+  build:
+    name: Build wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a new 'Build wheel' job to the PR validation workflow that builds the wheel and sdist using python -m build and uploads them as a GitHub Actions artifact. This makes it easy to share pre-built packages from any PR for testing.