### PR TITLE
Upgrade logging level to DEBUG to silence stderr warnings for user's not using langchain

### DIFF
--- a/src/microsoft/opentelemetry/_genai/_langchain/_tracer_instrumentor.py
+++ b/src/microsoft/opentelemetry/_genai/_langchain/_tracer_instrumentor.py
@@ -37,7 +37,7 @@ try:
     langchain_available = True
 except ImportError:  # pragma: no cover - exercised only when langchain-core absent
     langchain_available = False
-    logger.warning(
+    logger.debug(
         "LangChain instrumentation is disabled because 'langchain-core' is not "
         "installed. Install the optional extra with "
         "`pip install microsoft-opentelemetry[langchain]` to enable it."


### PR DESCRIPTION
The level has to be upgraded because in cases where the` LoggingHandler` is not initialized the missing langchain package warning was being sent to stderr polluting the console logs for user's who are not using the langchain instrumentation.

ex

```
use_microsoft_opentelemetry(enable_azure_monitor=True)

```

When the connection string is not provided, the langchain core missing package warning is flagged.