### PR TITLE
Add ContextualTokenResolver with agentic user ID support

### DIFF
--- a/src/microsoft/opentelemetry/_constants.py
+++ b/src/microsoft/opentelemetry/_constants.py
@@ -103,6 +103,7 @@ _SPECTRA_DEFAULT_HTTP_ENDPOINT = "http://localhost:4318"
 
 ENABLE_A365_ARG = "enable_a365"
 A365_TOKEN_RESOLVER_ARG = "a365_token_resolver"
+A365_CONTEXTUAL_TOKEN_RESOLVER_ARG = "a365_contextual_token_resolver"
 A365_CLUSTER_CATEGORY_ARG = "a365_cluster_category"
 A365_USE_S2S_ENDPOINT_ARG = "a365_use_s2s_endpoint"
 A365_SUPPRESS_INVOKE_AGENT_INPUT_ARG = "a365_suppress_invoke_agent_input"

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -35,6 +35,7 @@ from microsoft.opentelemetry._constants import (
     SPECTRA_PROTOCOL_ARG,
     SPECTRA_INSECURE_ARG,
     A365_TOKEN_RESOLVER_ARG,
+    A365_CONTEXTUAL_TOKEN_RESOLVER_ARG,
     A365_CLUSTER_CATEGORY_ARG,
     A365_USE_S2S_ENDPOINT_ARG,
     A365_SUPPRESS_INVOKE_AGENT_INPUT_ARG,
@@ -203,6 +204,7 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     enable_console: bool = bool(kwargs.pop(ENABLE_CONSOLE_ARG, False))
     enable_a365: bool = bool(kwargs.pop(ENABLE_A365_ARG, False))
     a365_token_resolver = kwargs.pop(A365_TOKEN_RESOLVER_ARG, None)
+    a365_contextual_token_resolver = kwargs.pop(A365_CONTEXTUAL_TOKEN_RESOLVER_ARG, None)
     a365_cluster_category = kwargs.pop(A365_CLUSTER_CATEGORY_ARG, None)
     a365_use_s2s_endpoint = kwargs.pop(A365_USE_S2S_ENDPOINT_ARG, None)
     a365_suppress_invoke_agent_input = kwargs.pop(A365_SUPPRESS_INVOKE_AGENT_INPUT_ARG, None)
@@ -281,6 +283,7 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
         enable_a365,
         otel_kwargs,
         token_resolver=a365_token_resolver,
+        contextual_token_resolver=a365_contextual_token_resolver,
         cluster_category=a365_cluster_category,
         use_s2s_endpoint=a365_use_s2s_endpoint,
         suppress_invoke_agent_input=a365_suppress_invoke_agent_input,
@@ -403,6 +406,7 @@ def _append_a365_components(
     enable_a365: bool,
     otel_kwargs: Dict[str, Any],
     token_resolver: Any = None,
+    contextual_token_resolver: Any = None,
     cluster_category: Any = None,
     use_s2s_endpoint: Any = None,
     suppress_invoke_agent_input: Any = None,
@@ -487,12 +491,17 @@ def _append_a365_components(
             )
             return
 
-        resolved_token_resolver = token_resolver or _create_default_token_resolver(
-            scope_override=resolved_scope_override
-        )
+        # Prefer contextual_token_resolver when set; fall back to token_resolver or default.
+        if contextual_token_resolver is not None:
+            resolved_token_resolver = None
+        else:
+            resolved_token_resolver = token_resolver or _create_default_token_resolver(
+                scope_override=resolved_scope_override
+            )
 
         exporter = _Agent365Exporter(
             token_resolver=resolved_token_resolver,
+            contextual_token_resolver=contextual_token_resolver,
             cluster_category=resolved_cluster_category,
             use_s2s_endpoint=resolved_use_s2s,
         )

--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -144,7 +144,14 @@ def use_microsoft_opentelemetry(**kwargs: object) -> None:  # pylint: disable=to
     :keyword a365_token_resolver:
         Optional callable ``(agent_id: str, tenant_id: str) -> str | None``
         used to authenticate with the Agent365 endpoint.  When omitted,
-        ``DefaultAzureCredential`` is used.
+        ``DefaultAzureCredential`` is used.  When both this and
+        ``a365_contextual_token_resolver`` are set, the contextual resolver
+        takes precedence.
+    :keyword a365_contextual_token_resolver:
+        Optional callable ``(TokenResolverContext) -> str | None`` used to
+        authenticate with the Agent365 endpoint.  Receives rich context
+        including the agentic user ID (AAD Object ID) extracted from span
+        attributes.  Takes precedence over ``a365_token_resolver`` when set.
     :keyword str a365_cluster_category:
         Cluster category for endpoint discovery. Also read from ``A365_CLUSTER_CATEGORY``
         env var. Defaults to ``"prod"``.

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -16,7 +16,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable, Sequence
-from typing import Any, final
+from typing import Any, Optional, final
 
 import requests
 from opentelemetry.sdk.trace import ReadableSpan
@@ -24,6 +24,10 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import StatusCode
 
 from microsoft.opentelemetry._sdkstats import is_sdkstats_enabled
+from microsoft.opentelemetry.a365.core.exporters.token_resolver_context import (
+    AgentIdentity,
+    TokenResolverContext,
+)
 from microsoft.opentelemetry.a365.core.exporters.utils import (
     DEFAULT_MAX_PAYLOAD_BYTES,
     build_export_url,
@@ -38,7 +42,7 @@ from microsoft.opentelemetry.a365.core.exporters.utils import (
     status_name,
     truncate_span,
 )
-from microsoft.opentelemetry.a365.constants import A365_HTTP_TIMEOUT_SECONDS
+from microsoft.opentelemetry.a365.constants import A365_HTTP_TIMEOUT_SECONDS, GEN_AI_AGENT_AUID_KEY
 
 # mypy: disable-error-code="import-untyped, union-attr"
 
@@ -172,19 +176,21 @@ class _Agent365Exporter(SpanExporter):
 
     def __init__(
         self,
-        token_resolver: Callable[[str, str], str | None],
+        token_resolver: Optional[Callable[[str, str], str | None]] = None,
+        contextual_token_resolver: Optional[Callable[[TokenResolverContext], str | None]] = None,
         cluster_category: str = "prod",
         use_s2s_endpoint: bool = False,
         max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
     ):
-        if token_resolver is None:
-            raise ValueError("token_resolver must be provided.")
+        if token_resolver is None and contextual_token_resolver is None:
+            raise ValueError("token_resolver or contextual_token_resolver must be provided.")
         if max_payload_bytes <= 0:
             raise ValueError(f"max_payload_bytes must be positive, got {max_payload_bytes}")
         self._session = requests.Session()
         self._closed = False
         self._lock = threading.Lock()
         self._token_resolver = token_resolver
+        self._contextual_token_resolver = contextual_token_resolver
         self._cluster_category = cluster_category
         self._use_s2s_endpoint = use_s2s_endpoint
         self._max_payload_bytes = max_payload_bytes
@@ -245,7 +251,21 @@ class _Agent365Exporter(SpanExporter):
 
                 headers: dict[str, str | bytes] = {"content-type": "application/json"}
                 try:
-                    token = self._token_resolver(agent_id, tenant_id)
+                    # Prefer contextual_token_resolver when set; extract agentic user ID
+                    # from the first span in the group (1:1 relationship between agent and user).
+                    if self._contextual_token_resolver is not None:
+                        agentic_user_id = None
+                        if activities:
+                            first_attrs = activities[0].attributes or {}
+                            agentic_user_id = first_attrs.get(GEN_AI_AGENT_AUID_KEY)
+                            if agentic_user_id is not None:
+                                agentic_user_id = str(agentic_user_id)
+                        identity = AgentIdentity(agent_id, agentic_user_id)
+                        context = TokenResolverContext(identity, tenant_id)
+                        token = self._contextual_token_resolver(context)
+                    else:
+                        token = self._token_resolver(agent_id, tenant_id)
+
                     if token:
                         if not url.lower().startswith("https://"):
                             logger.warning(

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -200,6 +200,22 @@ class _Agent365Exporter(SpanExporter):
 
     # ------------- SpanExporter API -----------------
 
+    def _resolve_token(
+        self, agent_id: str, tenant_id: str, activities: list[ReadableSpan]
+    ) -> Optional[str]:
+        """Resolve auth token, preferring contextual_token_resolver when set."""
+        if self._contextual_token_resolver is not None:
+            agentic_user_id: Optional[str] = None
+            if activities:
+                first_attrs = activities[0].attributes or {}
+                raw_auid = first_attrs.get(GEN_AI_AGENT_AUID_KEY)
+                if raw_auid is not None:
+                    agentic_user_id = str(raw_auid)
+            identity = AgentIdentity(agent_id, agentic_user_id)
+            context = TokenResolverContext(identity, tenant_id)
+            return self._contextual_token_resolver(context)
+        return self._token_resolver(agent_id, tenant_id)
+
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         if self._closed:
             return SpanExportResult.FAILURE
@@ -251,21 +267,7 @@ class _Agent365Exporter(SpanExporter):
 
                 headers: dict[str, str | bytes] = {"content-type": "application/json"}
                 try:
-                    # Prefer contextual_token_resolver when set; extract agentic user ID
-                    # from the first span in the group (1:1 relationship between agent and user).
-                    if self._contextual_token_resolver is not None:
-                        agentic_user_id = None
-                        if activities:
-                            first_attrs = activities[0].attributes or {}
-                            agentic_user_id = first_attrs.get(GEN_AI_AGENT_AUID_KEY)
-                            if agentic_user_id is not None:
-                                agentic_user_id = str(agentic_user_id)
-                        identity = AgentIdentity(agent_id, agentic_user_id)
-                        context = TokenResolverContext(identity, tenant_id)
-                        token = self._contextual_token_resolver(context)
-                    else:
-                        token = self._token_resolver(agent_id, tenant_id)
-
+                    token = self._resolve_token(agent_id, tenant_id, activities)
                     if token:
                         if not url.lower().startswith("https://"):
                             logger.warning(

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -171,7 +171,8 @@ class _Agent365Exporter(SpanExporter):
     * Partitions spans by (tenantId, agentId)
     * Builds OTLP-like JSON: resourceSpans -> scopeSpans -> spans
     * POSTs per group to the Agent365 observability endpoint
-    * Adds Bearer token via token_resolver(agentId, tenantId)
+    * Adds Bearer token via contextual_token_resolver(context) when set,
+      otherwise falls back to token_resolver(agentId, tenantId)
     """
 
     def __init__(
@@ -214,6 +215,8 @@ class _Agent365Exporter(SpanExporter):
             identity = AgentIdentity(agent_id, agentic_user_id)
             context = TokenResolverContext(identity, tenant_id)
             return self._contextual_token_resolver(context)
+        # Constructor guarantees at least one resolver is set.
+        assert self._token_resolver is not None
         return self._token_resolver(agent_id, tenant_id)
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter_options.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter_options.py
@@ -14,19 +14,22 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Optional
 
+from microsoft.opentelemetry.a365.core.exporters.token_resolver_context import TokenResolverContext
 from microsoft.opentelemetry.a365.core.exporters.utils import DEFAULT_MAX_PAYLOAD_BYTES
 
 
 class Agent365ExporterOptions:
     """Configuration for Agent365Exporter.
 
-    Only cluster_category and token_resolver are required for core operation.
+    Either ``token_resolver`` or ``contextual_token_resolver`` must be set.
+    When both are set, ``contextual_token_resolver`` takes precedence.
     """
 
     def __init__(
         self,
         cluster_category: str = "prod",
         token_resolver: Optional[Callable[[str, str], Optional[str]]] = None,
+        contextual_token_resolver: Optional[Callable[[TokenResolverContext], Optional[str]]] = None,
         use_s2s_endpoint: bool = False,
         max_queue_size: int = 2048,
         scheduled_delay_ms: int = 5000,
@@ -38,6 +41,11 @@ class Agent365ExporterOptions:
         Args:
             cluster_category: Cluster region argument. Defaults to 'prod'.
             token_resolver: Callable(agent_id, tenant_id) -> token string or None.
+                Either this or ``contextual_token_resolver`` must be set.
+                When both are set, ``contextual_token_resolver`` takes precedence.
+            contextual_token_resolver: Callable(TokenResolverContext) -> token string or None.
+                Provides rich context including the agentic user ID.
+                Takes precedence over ``token_resolver`` when set.
             use_s2s_endpoint: Use the S2S endpoint instead of standard endpoint.
             max_queue_size: Maximum queue size for the batch processor.
             scheduled_delay_ms: Delay between export batches (ms).
@@ -50,6 +58,7 @@ class Agent365ExporterOptions:
         """
         self.cluster_category = cluster_category
         self.token_resolver = token_resolver
+        self.contextual_token_resolver = contextual_token_resolver
         self.use_s2s_endpoint = use_s2s_endpoint
         self.max_queue_size = max_queue_size
         self.scheduled_delay_ms = scheduled_delay_ms

--- a/src/microsoft/opentelemetry/a365/core/exporters/token_resolver_context.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/token_resolver_context.py
@@ -1,0 +1,87 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+"""Token resolver context types for contextual token resolution.
+
+These types provide rich context to the token resolver delegate, including
+the agent identity (agent ID + agentic user ID) and tenant ID.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class AgentIdentity:
+    """Represents the identity of an agent and its acting user.
+
+    In the AI teammate scenario, ``agentic_user_id`` is 1:1 with ``agent_id``.
+    In the S2S scenario, ``agentic_user_id`` will be None.
+    """
+
+    __slots__ = ("_agent_id", "_agentic_user_id")
+
+    def __init__(self, agent_id: str, agentic_user_id: Optional[str] = None):
+        """
+        Args:
+            agent_id: The agent identifier.
+            agentic_user_id: The agentic user identifier (AAD Object ID),
+                or None in S2S scenarios.
+        """
+        if not agent_id:
+            raise ValueError("agent_id must be a non-empty string.")
+        self._agent_id = agent_id
+        self._agentic_user_id = agentic_user_id
+
+    @property
+    def agent_id(self) -> str:
+        """The agent identifier."""
+        return self._agent_id
+
+    @property
+    def agentic_user_id(self) -> Optional[str]:
+        """The agentic user identifier (AAD Object ID).
+
+        In the AI teammate scenario, this value is 1:1 with ``agent_id``.
+        Will be None in the S2S scenario.
+        """
+        return self._agentic_user_id
+
+
+class TokenResolverContext:
+    """Provides contextual information to the token resolver delegate.
+
+    ``identity`` provides first-class access to agent identity fields (agent ID,
+    agentic user ID). ``tenant_id`` and ``identity`` together identify the cache key.
+    """
+
+    __slots__ = ("_identity", "_tenant_id")
+
+    def __init__(self, identity: AgentIdentity, tenant_id: str):
+        """
+        Args:
+            identity: The agent identity associated with this request.
+            tenant_id: The tenant identifier (cache key).
+        """
+        if identity is None:
+            raise ValueError("identity must be provided.")
+        if not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string.")
+        self._identity = identity
+        self._tenant_id = tenant_id
+
+    @property
+    def identity(self) -> AgentIdentity:
+        """The agent identity associated with this token resolution request.
+
+        Contains the agent ID and agentic user ID (AAD Object ID) as first-class properties.
+        """
+        return self._identity
+
+    @property
+    def tenant_id(self) -> str:
+        """The tenant identifier (part of the cache key)."""
+        return self._tenant_id

--- a/src/microsoft/opentelemetry/a365/core/exporters/utils.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/utils.py
@@ -618,12 +618,16 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 def create_a365_components(
     token_resolver: Callable[[str, str], Optional[str]] | None = None,
+    contextual_token_resolver: Callable | None = None,
 ) -> A365Handlers:
     """Create Agent365 span processors ready to be added to a TracerProvider.
 
     :param token_resolver: Optional callable ``(agent_id, tenant_id) -> str | None``.
         When provided, it is used instead of the default ``DefaultAzureCredential``
         resolver.  This allows callers to supply FIC-based or other custom tokens.
+    :param contextual_token_resolver: Optional callable ``(TokenResolverContext) -> str | None``.
+        Provides rich context including the agentic user ID. Takes precedence over
+        ``token_resolver`` when set.
 
     All other configuration is read from environment variables:
       - ``ENABLE_A365_OBSERVABILITY_EXPORTER`` -- must be true for the HTTP exporter
@@ -637,22 +641,28 @@ def create_a365_components(
     from microsoft.opentelemetry.a365.core.exporters.agent365_exporter_options import Agent365ExporterOptions
     from microsoft.opentelemetry.a365.core.exporters.span_processor import A365SpanProcessor
 
-    if token_resolver is None:
-        token_resolver = _create_default_token_resolver()
+    if contextual_token_resolver is not None:
+        resolved_token_resolver = None
+    elif token_resolver is None:
+        resolved_token_resolver = _create_default_token_resolver()
+    else:
+        resolved_token_resolver = token_resolver
     cluster_category = os.environ.get(A365_CLUSTER_CATEGORY_ENV, "prod")
     use_s2s_endpoint = _env_bool(A365_USE_S2S_ENDPOINT_ENV)
     suppress_invoke_agent_input = _env_bool(A365_SUPPRESS_INVOKE_AGENT_INPUT_ENV)
 
     options = Agent365ExporterOptions(
         cluster_category=cluster_category,
-        token_resolver=token_resolver,
+        token_resolver=resolved_token_resolver,
+        contextual_token_resolver=contextual_token_resolver,
         use_s2s_endpoint=use_s2s_endpoint,
     )
 
     # Create the exporter (Agent365 HTTP or console fallback)
-    if is_agent365_exporter_enabled() and options.token_resolver is not None:
+    if is_agent365_exporter_enabled() and (options.token_resolver is not None or options.contextual_token_resolver is not None):
         exporter = _Agent365Exporter(
             token_resolver=options.token_resolver,
+            contextual_token_resolver=options.contextual_token_resolver,
             cluster_category=options.cluster_category,
             use_s2s_endpoint=options.use_s2s_endpoint,
             max_payload_bytes=options.max_payload_bytes,

--- a/src/microsoft/opentelemetry/a365/core/exporters/utils.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/utils.py
@@ -18,7 +18,7 @@ import threading
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, List, Optional, TypeVar
 from urllib.parse import urlparse
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -47,6 +47,9 @@ from microsoft.opentelemetry.a365.constants import (
     TENANT_ID_KEY,
 )
 from microsoft.opentelemetry.a365.core.inference_operation_type import InferenceOperationType
+
+if TYPE_CHECKING:
+    from microsoft.opentelemetry.a365.core.exporters.token_resolver_context import TokenResolverContext
 
 logger = logging.getLogger(__name__)
 
@@ -618,7 +621,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 def create_a365_components(
     token_resolver: Callable[[str, str], Optional[str]] | None = None,
-    contextual_token_resolver: Callable | None = None,
+    contextual_token_resolver: Callable[[TokenResolverContext], Optional[str]] | None = None,
 ) -> A365Handlers:
     """Create Agent365 span processors ready to be added to a TracerProvider.
 
@@ -659,7 +662,8 @@ def create_a365_components(
     )
 
     # Create the exporter (Agent365 HTTP or console fallback)
-    if is_agent365_exporter_enabled() and (options.token_resolver is not None or options.contextual_token_resolver is not None):
+    has_resolver = options.token_resolver is not None or options.contextual_token_resolver is not None
+    if is_agent365_exporter_enabled() and has_resolver:
         exporter = _Agent365Exporter(
             token_resolver=options.token_resolver,
             contextual_token_resolver=options.contextual_token_resolver,
@@ -669,7 +673,7 @@ def create_a365_components(
         )
     else:
         logger.warning(
-            "ENABLE_A365_OBSERVABILITY_EXPORTER not set or token_resolver not provided. "
+            "ENABLE_A365_OBSERVABILITY_EXPORTER not set or no token resolver provided. "
             "A365 exporter will not be active."
         )
         return A365Handlers()

--- a/tests/a365/test_contextual_token_resolver.py
+++ b/tests/a365/test_contextual_token_resolver.py
@@ -1,0 +1,242 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.trace import SpanKind, StatusCode
+
+from microsoft.opentelemetry.a365.core.exporters.agent365_exporter import (
+    _Agent365Exporter,
+)
+from microsoft.opentelemetry.a365.core.exporters.token_resolver_context import (
+    AgentIdentity,
+    TokenResolverContext,
+)
+
+
+def _make_span(
+    tenant_id="t1",
+    agent_id="a1",
+    agentic_user_id=None,
+    name="test_span",
+    trace_id=0x1234,
+    span_id=0x5678,
+    operation_name="invoke_agent",
+):
+    span = MagicMock()
+    span.name = name
+    attrs = {
+        "microsoft.tenant.id": tenant_id,
+        "gen_ai.agent.id": agent_id,
+    }
+    if operation_name is not None:
+        attrs["gen_ai.operation.name"] = operation_name
+    if agentic_user_id is not None:
+        attrs["microsoft.agent.user.id"] = agentic_user_id
+    span.attributes = attrs
+
+    ctx = MagicMock()
+    ctx.trace_id = trace_id
+    ctx.span_id = span_id
+    span.context = ctx
+    span.get_span_context.return_value = ctx
+
+    span.parent = None
+    span.kind = SpanKind.INTERNAL
+    span.start_time = 1000000000
+    span.end_time = 2000000000
+
+    status = MagicMock()
+    status.status_code = StatusCode.OK
+    status.description = ""
+    span.status = status
+
+    span.events = []
+    span.links = []
+
+    scope = MagicMock()
+    scope.name = "test_scope"
+    scope.version = "1.0"
+    span.instrumentation_scope = scope
+
+    resource = MagicMock()
+    resource.attributes = {"service.name": "test-service"}
+    span.resource = resource
+
+    return span
+
+
+class TestAgentIdentity(unittest.TestCase):
+    def test_creates_with_agent_id_only(self):
+        identity = AgentIdentity("agent-123")
+        self.assertEqual(identity.agent_id, "agent-123")
+        self.assertIsNone(identity.agentic_user_id)
+
+    def test_creates_with_both_ids(self):
+        identity = AgentIdentity("agent-123", "user-456")
+        self.assertEqual(identity.agent_id, "agent-123")
+        self.assertEqual(identity.agentic_user_id, "user-456")
+
+    def test_raises_on_empty_agent_id(self):
+        with self.assertRaises(ValueError):
+            AgentIdentity("")
+
+    def test_raises_on_none_agent_id(self):
+        with self.assertRaises(ValueError):
+            AgentIdentity(None)
+
+
+class TestTokenResolverContext(unittest.TestCase):
+    def test_creates_with_identity_and_tenant(self):
+        identity = AgentIdentity("agent-1", "user-1")
+        context = TokenResolverContext(identity, "tenant-1")
+        self.assertEqual(context.identity.agent_id, "agent-1")
+        self.assertEqual(context.identity.agentic_user_id, "user-1")
+        self.assertEqual(context.tenant_id, "tenant-1")
+
+    def test_raises_on_none_identity(self):
+        with self.assertRaises(ValueError):
+            TokenResolverContext(None, "tenant-1")
+
+    def test_raises_on_empty_tenant_id(self):
+        identity = AgentIdentity("agent-1")
+        with self.assertRaises(ValueError):
+            TokenResolverContext(identity, "")
+
+
+class TestContextualTokenResolverInit(unittest.TestCase):
+    def test_raises_when_neither_resolver_provided(self):
+        with self.assertRaises(ValueError):
+            _Agent365Exporter(token_resolver=None, contextual_token_resolver=None)
+
+    def test_creates_with_contextual_resolver_only(self):
+        exporter = _Agent365Exporter(contextual_token_resolver=lambda ctx: "token")
+        self.assertIsNotNone(exporter)
+        exporter.shutdown()
+
+    def test_creates_with_token_resolver_only(self):
+        exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+        self.assertIsNotNone(exporter)
+        exporter.shutdown()
+
+    def test_creates_with_both_resolvers(self):
+        exporter = _Agent365Exporter(
+            token_resolver=lambda a, t: "token1",
+            contextual_token_resolver=lambda ctx: "token2",
+        )
+        self.assertIsNotNone(exporter)
+        exporter.shutdown()
+
+
+class TestContextualTokenResolverExport(unittest.TestCase):
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_contextual_resolver_called_with_context(self, mock_post):
+        mock_post.return_value = True
+        resolver = MagicMock(return_value="ctx-token")
+        exporter = _Agent365Exporter(contextual_token_resolver=resolver)
+        span = _make_span(tenant_id="t1", agent_id="a1", agentic_user_id="user-42")
+        exporter.export([span])
+
+        resolver.assert_called_once()
+        ctx = resolver.call_args[0][0]
+        self.assertIsInstance(ctx, TokenResolverContext)
+        self.assertEqual(ctx.identity.agent_id, "a1")
+        self.assertEqual(ctx.identity.agentic_user_id, "user-42")
+        self.assertEqual(ctx.tenant_id, "t1")
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_contextual_resolver_null_agentic_user_id(self, mock_post):
+        mock_post.return_value = True
+        resolver = MagicMock(return_value="ctx-token")
+        exporter = _Agent365Exporter(contextual_token_resolver=resolver)
+        span = _make_span(tenant_id="t1", agent_id="a1")  # no agentic_user_id
+        exporter.export([span])
+
+        ctx = resolver.call_args[0][0]
+        self.assertIsNone(ctx.identity.agentic_user_id)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_contextual_resolver_takes_precedence_over_token_resolver(self, mock_post):
+        mock_post.return_value = True
+        token_resolver = MagicMock(return_value="old-token")
+        contextual_resolver = MagicMock(return_value="new-token")
+        exporter = _Agent365Exporter(
+            token_resolver=token_resolver,
+            contextual_token_resolver=contextual_resolver,
+        )
+        span = _make_span(tenant_id="t1", agent_id="a1")
+        exporter.export([span])
+
+        # contextual_resolver should be called; token_resolver should NOT
+        contextual_resolver.assert_called_once()
+        token_resolver.assert_not_called()
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_token_resolver_used_when_no_contextual(self, mock_post):
+        mock_post.return_value = True
+        token_resolver = MagicMock(return_value="old-token")
+        exporter = _Agent365Exporter(token_resolver=token_resolver)
+        span = _make_span(tenant_id="t1", agent_id="a1")
+        exporter.export([span])
+
+        token_resolver.assert_called_once_with("a1", "t1")
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_contextual_resolver_exception_marks_failure(self, mock_post):
+        mock_post.return_value = True
+        resolver = MagicMock(side_effect=Exception("auth error"))
+        exporter = _Agent365Exporter(contextual_token_resolver=resolver)
+        span = _make_span(tenant_id="t1", agent_id="a1")
+        result = exporter.export([span])
+        self.assertEqual(result, SpanExportResult.FAILURE)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter._Agent365Exporter._post_with_retries")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_contextual_resolver_returns_none_no_auth_header(self, mock_post):
+        mock_post.return_value = True
+        resolver = MagicMock(return_value=None)
+        exporter = _Agent365Exporter(contextual_token_resolver=resolver)
+        span = _make_span(tenant_id="t1", agent_id="a1")
+        result = exporter.export([span])
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        exporter.shutdown()
+
+
+class TestExporterOptionsContextualResolver(unittest.TestCase):
+    def test_options_accepts_contextual_resolver(self):
+        from microsoft.opentelemetry.a365.core.exporters.agent365_exporter_options import (
+            Agent365ExporterOptions,
+        )
+
+        resolver = lambda ctx: "token"
+        opts = Agent365ExporterOptions(contextual_token_resolver=resolver)
+        self.assertIs(opts.contextual_token_resolver, resolver)
+        self.assertIsNone(opts.token_resolver)
+
+    def test_options_accepts_both_resolvers(self):
+        from microsoft.opentelemetry.a365.core.exporters.agent365_exporter_options import (
+            Agent365ExporterOptions,
+        )
+
+        tr = lambda a, t: "token1"
+        cr = lambda ctx: "token2"
+        opts = Agent365ExporterOptions(token_resolver=tr, contextual_token_resolver=cr)
+        self.assertIs(opts.token_resolver, tr)
+        self.assertIs(opts.contextual_token_resolver, cr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/a365/test_contextual_token_resolver.py
+++ b/tests/a365/test_contextual_token_resolver.py
@@ -221,7 +221,9 @@ class TestExporterOptionsContextualResolver(unittest.TestCase):
             Agent365ExporterOptions,
         )
 
-        resolver = lambda ctx: "token"
+        def resolver(ctx):
+            return "token"
+
         opts = Agent365ExporterOptions(contextual_token_resolver=resolver)
         self.assertIs(opts.contextual_token_resolver, resolver)
         self.assertIsNone(opts.token_resolver)
@@ -231,8 +233,12 @@ class TestExporterOptionsContextualResolver(unittest.TestCase):
             Agent365ExporterOptions,
         )
 
-        tr = lambda a, t: "token1"
-        cr = lambda ctx: "token2"
+        def tr(a, t):
+            return "token1"
+
+        def cr(ctx):
+            return "token2"
+
         opts = Agent365ExporterOptions(token_resolver=tr, contextual_token_resolver=cr)
         self.assertIs(opts.token_resolver, tr)
         self.assertIs(opts.contextual_token_resolver, cr)


### PR DESCRIPTION
## Summary

Python port of https://github.com/microsoft/opentelemetry-distro-dotnet/pull/101.

Introduces `AgentIdentity` and `TokenResolverContext` classes that allow the agentic user ID to be passed alongside agent and tenant IDs during token resolution at export time.

## Changes

### New files
- **`token_resolver_context.py`** — `AgentIdentity` (agent_id + agentic_user_id) and `TokenResolverContext` (identity + tenant_id)
- **`test_contextual_token_resolver.py`** — 19 tests covering the new types and exporter behavior

### Modified files
- **`agent365_exporter_options.py`** — Added `contextual_token_resolver` parameter
- **`agent365_exporter.py`** — Accept either resolver; prefer `contextual_token_resolver` at export time, extracting `microsoft.agent.user.id` from span attributes
- **`_constants.py`** — Added `A365_CONTEXTUAL_TOKEN_RESOLVER_ARG`
- **`_distro.py`** — Thread `contextual_token_resolver` through configure → _append_a365_components → exporter
- **`utils.py`** — Updated `create_a365_components()` to accept and forward contextual resolver

## Behavior

- When `contextual_token_resolver` is set, it takes precedence over `token_resolver`
- The exporter extracts `microsoft.agent.user.id` from the first span in each identity group and passes it via `TokenResolverContext`
- Fully backward-compatible — existing `token_resolver` usage is unchanged

## Testing

All 320 existing A365 tests pass + 19 new tests added.