### PR TITLE
ci(perf): post sticky comment for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -1,0 +1,72 @@
+name: Performance Comment
+
+# Posts the perf comparison as a sticky PR comment.
+#
+# This runs in the *base* repository's context via `workflow_run`, which
+# means it has a writable `GITHUB_TOKEN` even for pull requests opened from
+# forks. The Performance workflow itself runs in the (potentially untrusted)
+# PR context and only produces an artifact — no PR write permissions there.
+
+on:
+  workflow_run:
+    workflows: ["Performance"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post sticky PR comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download perf-results artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-results
+          path: perf-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          if [ -f perf-results/pr-number.txt ]; then
+            pr="$(tr -d '[:space:]' < perf-results/pr-number.txt)"
+          else
+            pr=""
+          fi
+
+          if [ -z "$pr" ]; then
+            echo "Could not determine PR number; skipping comment." >&2
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Verify report exists
+        id: report
+        if: steps.pr.outputs.number != ''
+        run: |
+          if [ -s perf-results/report.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "report.md missing or empty; skipping comment." >&2
+          fi
+
+      - name: Post sticky PR comment
+        if: steps.pr.outputs.number != '' && steps.report.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: perf-comparison
+          number: ${{ steps.pr.outputs.number }}
+          path: perf-results/report.md

--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -6,6 +6,14 @@ name: Performance Comment
 # means it has a writable `GITHUB_TOKEN` even for pull requests opened from
 # forks. The Performance workflow itself runs in the (potentially untrusted)
 # PR context and only produces an artifact — no PR write permissions there.
+#
+# Security model:
+#   * The artifact from the PR-context workflow is treated as untrusted
+#     input. We only consume the JSON benchmark outputs (`base.json` /
+#     `pr.json`) and the PR number, and we regenerate `report.md` here
+#     using the base repository's checked-out `perf.compare` so the
+#     markdown posted under the writable token is never attacker-supplied.
+#   * The PR number is validated as a positive integer before being used.
 
 on:
   workflow_run:
@@ -25,8 +33,14 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
 
     steps:
+      - name: Check out base repository (trusted)
+        uses: actions/checkout@v4
+
       - name: Download perf-results artifact
         id: download
+        # Don't fail this job if the upstream Performance run was cancelled
+        # or failed before producing the artifact — we just skip posting.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: perf-results
@@ -36,31 +50,54 @@ jobs:
 
       - name: Resolve PR number
         id: pr
+        if: steps.download.outcome == 'success'
         run: |
           set -euo pipefail
+          pr=""
           if [ -f perf-results/pr-number.txt ]; then
             pr="$(tr -d '[:space:]' < perf-results/pr-number.txt)"
-          else
-            pr=""
           fi
 
-          if [ -z "$pr" ]; then
-            echo "Could not determine PR number; skipping comment." >&2
+          if ! [[ "$pr" =~ ^[1-9][0-9]*$ ]]; then
+            echo "pr-number.txt missing or not a positive integer (got: '${pr}'); skipping comment." >&2
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "number=$pr" >> "$GITHUB_OUTPUT"
 
-      - name: Verify report exists
+      - name: Set up Python
+        if: steps.pr.outputs.number != ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Regenerate report from JSON (trusted code)
         id: report
         if: steps.pr.outputs.number != ''
         run: |
-          if [ -s perf-results/report.md ]; then
+          set -euo pipefail
+          if [ ! -s perf-results/base.json ] || [ ! -s perf-results/pr.json ]; then
+            echo "base.json or pr.json missing from artifact; skipping comment." >&2
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Use the base repo's perf.compare (trusted) to render the markdown
+          # from the PR-supplied JSON data, so we never post attacker-supplied
+          # markdown under the base repo's writable token.
+          python -m perf.compare \
+            --baseline perf-results/base.json \
+            --candidate perf-results/pr.json \
+            --threshold "${PERF_REGRESSION_THRESHOLD:-15}" \
+            --output report.md \
+            || true
+
+          if [ -s report.md ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "report.md missing or empty; skipping comment." >&2
+            echo "report.md was not produced; skipping comment." >&2
           fi
 
       - name: Post sticky PR comment
@@ -69,4 +106,4 @@ jobs:
         with:
           header: perf-comparison
           number: ${{ steps.pr.outputs.number }}
-          path: perf-results/report.md
+          path: report.md

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -94,6 +94,10 @@ jobs:
             --output "$GITHUB_WORKSPACE/report.md"
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
+      - name: Record PR number
+        if: always() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > "$GITHUB_WORKSPACE/pr-number.txt"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -103,17 +107,8 @@ jobs:
             pr.json
             base.json
             report.md
-
-      - name: Post sticky PR comment
-        # Skip for PRs from forks — the default GITHUB_TOKEN has read-only
-        # access in that case and the comment API will reject the call. The
-        # JSON artifacts and the workflow log still contain the comparison.
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: perf-comparison
-          path: report.md
+            pr-number.txt
+          if-no-files-found: ignore
 
       - name: Fail on regression
         if: steps.compare.outputs.exit_code != '0'


### PR DESCRIPTION
## Why

The `Performance` workflow runs in the PR's context, which means the `GITHUB_TOKEN` is read-only for pull requests opened from forks. The `Post sticky PR comment` step is therefore gated off whenever `github.event.pull_request.head.repo.full_name != github.repository`, so the perf comparison never appears on cross-repository PRs (e.g. #182).

## What

- New `performance-comment.yml` workflow triggered by `workflow_run` of `Performance`. Because `workflow_run` runs in the *base* repository's context, it has `pull-requests: write` even for fork PRs.
- `performance.yml` now records the PR number in `pr-number.txt` and uploads it alongside `report.md`. The follow-up workflow downloads the `perf-results` artifact and uses that PR number to post the sticky comment with `marocchino/sticky-pull-request-comment@v2`.
- Removed the in-place `Post sticky PR comment` step (and its fork gate) from `performance.yml` so we don't double-post for same-repo PRs.

## Notes

- `workflow_run` jobs execute against the base branch's workflow definition, so this is safe even though the upstream perf job runs untrusted PR code — the comment job only consumes the produced artifact.
- `if-no-files-found: ignore` keeps the artifact upload from failing if an earlier step crashed before producing `report.md`; in that case the comment job sees an empty/missing report and skips posting rather than erroring.