### PR TITLE
Add remaining network sdkstats metrics for A365

### DIFF
--- a/src/microsoft/opentelemetry/_distro.py
+++ b/src/microsoft/opentelemetry/_distro.py
@@ -417,7 +417,7 @@ def _initialize_sdkstats(enable_azure_monitor: bool) -> None:
         manager.initialize(config)
 
         # Since azure monitor is disabled, the cikey is not applicable.
-        _StatsbeatMetrics._COMMON_ATTRIBUTES["cikey"] = "n/a"  # pylint: disable=protected-access
+        _StatsbeatMetrics._COMMON_ATTRIBUTES["cikey"] = "N/A"  # pylint: disable=protected-access
 
     # Register distro-owned network gauge on the manager's MeterProvider.
     from microsoft.opentelemetry._sdkstats._network_metrics import (

--- a/src/microsoft/opentelemetry/_sdkstats/_constants.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_constants.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 
+
 from azure.monitor.opentelemetry.exporter._constants import (  # type: ignore[import-not-found]
     _REQ_DURATION_NAME,
     _REQ_EXCEPTION_NAME,

--- a/src/microsoft/opentelemetry/_sdkstats/_constants.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_constants.py
@@ -5,12 +5,24 @@
 # --------------------------------------------------------------------------
 
 
-
 from azure.monitor.opentelemetry.exporter._constants import (  # type: ignore[import-not-found]
+    _REQ_DURATION_NAME,
+    _REQ_EXCEPTION_NAME,
+    _REQ_FAILURE_NAME,
+    _REQ_RETRY_NAME,
     _REQ_SUCCESS_NAME,
+    _REQ_THROTTLE_NAME,
+    _THROTTLE_STATUS_CODES,
 )
 
+REQUEST_DURATION_NAME = _REQ_DURATION_NAME[0]
+REQUEST_EXCEPTION_NAME = _REQ_EXCEPTION_NAME[0]
+REQUEST_FAILURE_NAME = _REQ_FAILURE_NAME[0]
+REQUEST_RETRY_NAME = _REQ_RETRY_NAME[0]
 REQUEST_SUCCESS_NAME = _REQ_SUCCESS_NAME[0]
+REQUEST_THROTTLE_NAME = _REQ_THROTTLE_NAME[0]
+
+THROTTLE_STATUS_CODES = _THROTTLE_STATUS_CODES
 
 
 # Endpoint type enum values for the ``endpoint`` dimension on network sdkstats

--- a/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
@@ -23,7 +23,12 @@ from typing import Iterable, List
 from opentelemetry.metrics import CallbackOptions, Observation
 
 from microsoft.opentelemetry._sdkstats._utils import (
+    REQUEST_DURATION_NAME,
+    REQUEST_EXCEPTION_NAME,
+    REQUEST_FAILURE_NAME,
+    REQUEST_RETRY_NAME,
     REQUEST_SUCCESS_NAME,
+    REQUEST_THROTTLE_NAME,
     drain,
 )
 
@@ -33,6 +38,8 @@ try:
     )
 except ImportError:  # pragma: no cover
     _StatsbeatMetrics = None  # type: ignore[assignment,misc]
+
+from microsoft.opentelemetry._version import VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -47,12 +54,12 @@ def _get_common_attributes() -> dict:
 
 
 def _observe_request_success_count(options: CallbackOptions) -> Iterable[Observation]:
-    """Drain the per-endpoint success counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
     for key, value in drain(REQUEST_SUCCESS_NAME).items():
         attributes = dict(common)
+        attributes["version"] = VERSION
         attributes["endpoint"] = key[0]
         attributes["host"] = key[1]
         attributes["statusCode"] = 200
@@ -60,13 +67,90 @@ def _observe_request_success_count(options: CallbackOptions) -> Iterable[Observa
     return observations
 
 
+def _observe_request_duration(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain accumulated (sum_seconds, count) per (endpoint, host) and
+    emit the interval *average* duration in milliseconds — matches
+    upstream's ``Request_Duration`` semantics."""
+    common = _get_common_attributes()
+
+    observations: List[Observation] = []
+    for key, value in drain(REQUEST_DURATION_NAME).items():
+        total_seconds, count = value
+        if count <= 0:
+            continue
+        avg_ms = (total_seconds / count) * 1000.0
+        attributes = dict(common)
+        attributes["version"] = VERSION
+        attributes["endpoint"] = key[0]
+        attributes["host"] = key[1]
+        observations.append(Observation(avg_ms, attributes))
+    return observations
+
+
+def _observe_request_failure_count(options: CallbackOptions) -> Iterable[Observation]:
+    common = _get_common_attributes()
+
+    observations: List[Observation] = []
+    for key, value in drain(REQUEST_FAILURE_NAME).items():
+        attributes = dict(common)
+        attributes["version"] = VERSION
+        attributes["endpoint"] = key[0]
+        attributes["host"] = key[1]
+        attributes["statusCode"] = key[2]
+        observations.append(Observation(value, attributes))
+    return observations
+
+
+def _observe_request_retry_count(options: CallbackOptions) -> Iterable[Observation]:
+    common = _get_common_attributes()
+
+    observations: List[Observation] = []
+    for key, value in drain(REQUEST_RETRY_NAME).items():
+        attributes = dict(common)
+        attributes["version"] = VERSION
+        attributes["endpoint"] = key[0]
+        attributes["host"] = key[1]
+        attributes["statusCode"] = key[2]
+        observations.append(Observation(value, attributes))
+    return observations
+
+
+def _observe_request_throttle_count(options: CallbackOptions) -> Iterable[Observation]:
+    common = _get_common_attributes()
+
+    observations: List[Observation] = []
+    for key, value in drain(REQUEST_THROTTLE_NAME).items():
+        attributes = dict(common)
+        attributes["version"] = VERSION
+        attributes["endpoint"] = key[0]
+        attributes["host"] = key[1]
+        attributes["statusCode"] = key[2]
+        observations.append(Observation(value, attributes))
+    return observations
+
+
+def _observe_request_exception_count(options: CallbackOptions) -> Iterable[Observation]:
+    common = _get_common_attributes()
+
+    observations: List[Observation] = []
+    for key, value in drain(REQUEST_EXCEPTION_NAME).items():
+        attributes = dict(common)
+        attributes["version"] = VERSION
+        attributes["endpoint"] = key[0]
+        attributes["host"] = key[1]
+        attributes["exceptionType"] = key[2]
+        observations.append(Observation(value, attributes))
+    return observations
+
+
 def register_network_gauges() -> bool:
     """Attach distro network-stats callbacks to upstream's gauges.
 
-    The distro emits per-endpoint ``Request_Success_Count`` observation
-    via the upstream statsbeat pipeline.  We cannot create separate gauges 
-    with the same names because the stats backend identifies metric streams by
-    InstrumentationScope, and rows from an unknown scope are silently
+    The distro emits per-endpoint (``Request_Success_Count``, ``Request_Duration``,
+    ``Request_Failure_Count``, ``Retry_Count``, ``Throttle_Count``,
+    ``Exception_Count``) observations via the upstream statsbeat pipeline.  We cannot
+    create separate gauges with the same names because the stats backend identifies
+    metric streams by InstrumentationScope, and rows from an unknown scope are silently
     dropped.  Instead we append our callbacks to the already-registered
     upstream ``_success_count`` observable gauges
     so our observations are emitted on the exact same instrument/scope
@@ -101,6 +185,11 @@ def register_network_gauges() -> bool:
         attached: List[str] = []
         for gauge_attr, callback in (
             ("_success_count", _observe_request_success_count),
+            ("_average_duration", _observe_request_duration),
+            ("_failure_count", _observe_request_failure_count),
+            ("_retry_count", _observe_request_retry_count),
+            ("_throttle_count", _observe_request_throttle_count),
+            ("_exception_count", _observe_request_exception_count),
         ):
             gauge = getattr(metrics, gauge_attr, None)
             if gauge is None:
@@ -110,7 +199,8 @@ def register_network_gauges() -> bool:
                 gauge._callbacks.append(callback)  # pylint: disable=protected-access
             except AttributeError:
                 logger.debug(
-                    "Upstream %s gauge has no _callbacks list; cannot attach.", gauge_attr,
+                    "Upstream %s gauge has no _callbacks list; cannot attach.",
+                    gauge_attr,
                 )
                 continue
             attached.append(gauge_attr)

--- a/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
@@ -54,6 +54,7 @@ def _get_common_attributes() -> dict:
 
 
 def _observe_request_success_count(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain the per-endpoint success counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
@@ -88,6 +89,7 @@ def _observe_request_duration(options: CallbackOptions) -> Iterable[Observation]
 
 
 def _observe_request_failure_count(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain the per-endpoint failure counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
@@ -102,6 +104,7 @@ def _observe_request_failure_count(options: CallbackOptions) -> Iterable[Observa
 
 
 def _observe_request_retry_count(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain the per-endpoint retry counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
@@ -116,6 +119,7 @@ def _observe_request_retry_count(options: CallbackOptions) -> Iterable[Observati
 
 
 def _observe_request_throttle_count(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain the per-endpoint throttle counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
@@ -130,6 +134,7 @@ def _observe_request_throttle_count(options: CallbackOptions) -> Iterable[Observ
 
 
 def _observe_request_exception_count(options: CallbackOptions) -> Iterable[Observation]:
+    """Drain the per-endpoint exception counts and emit one observation each."""
     common = _get_common_attributes()
 
     observations: List[Observation] = []
@@ -152,9 +157,8 @@ def register_network_gauges() -> bool:
     create separate gauges with the same names because the stats backend identifies
     metric streams by InstrumentationScope, and rows from an unknown scope are silently
     dropped.  Instead we append our callbacks to the already-registered
-    upstream ``_success_count`` observable gauges
-    so our observations are emitted on the exact same instrument/scope
-    as upstream's breeze rows.
+    upstream observable gauges so our observations are emitted on the
+    exact same instrument/scope as upstream's breeze rows.
 
     Idempotent — subsequent calls are no-ops.  Returns ``True`` on the
     call that performs registration, ``False`` if registration was

--- a/src/microsoft/opentelemetry/_sdkstats/_utils.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_utils.py
@@ -9,9 +9,17 @@
 from __future__ import annotations
 
 import threading
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
-from microsoft.opentelemetry._sdkstats._constants import REQUEST_SUCCESS_NAME
+from microsoft.opentelemetry._sdkstats._constants import (
+    REQUEST_DURATION_NAME,
+    REQUEST_EXCEPTION_NAME,
+    REQUEST_FAILURE_NAME,
+    REQUEST_RETRY_NAME,
+    REQUEST_SUCCESS_NAME,
+    REQUEST_THROTTLE_NAME,
+    THROTTLE_STATUS_CODES,
+)
 
 # ===========================================================================
 # Global state helpers (Azure Monitor exporter statsbeat bridge)
@@ -44,22 +52,43 @@ def update_global_state_instrumentation_bits(instrumentation_bits: int) -> None:
 # Network sdkstats
 # ===========================================================================
 #
-# Per-export success counts for telemetry exporters.  Exporters call
-# ``record_success`` after each successful transmit; the
-# ``SdkStatsMetrics`` callback drains the accumulated counts on each
+# Per-export counters and per-request duration accumulators for telemetry
+# exporters.  Exporters call the ``record_*`` helpers; the observable
+# callbacks in ``_network_metrics`` drain the accumulated state on each
 # export interval.
 
-__all__ = ["record_success", "drain", "reset_all"]
+__all__ = [
+    "THROTTLE_STATUS_CODES",
+    "REQUEST_SUCCESS_NAME",
+    "REQUEST_DURATION_NAME",
+    "REQUEST_FAILURE_NAME",
+    "REQUEST_RETRY_NAME",
+    "REQUEST_THROTTLE_NAME",
+    "REQUEST_EXCEPTION_NAME",
+    "record_success",
+    "record_duration",
+    "record_failure",
+    "record_retry",
+    "record_throttle",
+    "record_exception",
+    "drain",
+    "reset_all",
+]
 
 
 _REQUESTS_MAP_LOCK = threading.Lock()
-_REQUESTS_MAP: Dict[str, Dict[Tuple[str, ...], float]] = {
+_REQUESTS_MAP: Dict[str, Dict[Tuple[Any, ...], Any]] = {
     REQUEST_SUCCESS_NAME: {},
+    REQUEST_DURATION_NAME: {},
+    REQUEST_FAILURE_NAME: {},
+    REQUEST_RETRY_NAME: {},
+    REQUEST_THROTTLE_NAME: {},
+    REQUEST_EXCEPTION_NAME: {},
 }
 
 
 # Increment the counter for the given metric/key by the given value (default 1.0).
-def _bump(metric: str, key: Tuple[str, ...], value: float = 1.0) -> None:
+def _bump(metric: str, key: Tuple[Any, ...], value: float = 1.0) -> None:
     with _REQUESTS_MAP_LOCK:
         bucket = _REQUESTS_MAP[metric]
         bucket[key] = bucket.get(key, 0) + value
@@ -69,8 +98,38 @@ def record_success(endpoint: str, host: str) -> None:
     _bump(REQUEST_SUCCESS_NAME, (endpoint, host))
 
 
+def record_duration(endpoint: str, host: str, duration_seconds: float) -> None:
+    """Record one request-duration sample (in seconds) for averaging.
+
+    Stored as a running (sum_seconds, count) tuple per (endpoint, host) so
+    the observable callback can compute an interval average without
+    retaining individual samples.
+    """
+    key = (endpoint, host)
+    with _REQUESTS_MAP_LOCK:
+        bucket = _REQUESTS_MAP[REQUEST_DURATION_NAME]
+        existing = bucket.get(key, (0.0, 0))
+        bucket[key] = (existing[0] + float(duration_seconds), existing[1] + 1)
+
+
+def record_failure(endpoint: str, host: str, status_code: int) -> None:
+    _bump(REQUEST_FAILURE_NAME, (endpoint, host, int(status_code)))
+
+
+def record_retry(endpoint: str, host: str, status_code: int) -> None:
+    _bump(REQUEST_RETRY_NAME, (endpoint, host, int(status_code)))
+
+
+def record_throttle(endpoint: str, host: str, status_code: int) -> None:
+    _bump(REQUEST_THROTTLE_NAME, (endpoint, host, int(status_code)))
+
+
+def record_exception(endpoint: str, host: str, exception_type: str) -> None:
+    _bump(REQUEST_EXCEPTION_NAME, (endpoint, host, str(exception_type)))
+
+
 # Returns the counts accumulated since the last call, and resets the counters to zero.
-def drain(metric: str) -> Dict[Tuple[str, ...], float]:
+def drain(metric: str) -> Dict[Tuple[Any, ...], Any]:
     with _REQUESTS_MAP_LOCK:
         bucket = _REQUESTS_MAP[metric]
         snapshot = dict(bucket)

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -363,9 +363,9 @@ class _Agent365Exporter(SpanExporter):
             return text[:max_length] + "..."
         return text
 
-    def _post_with_retries(
+    def _post_with_retries(  # pylint: disable=too-many-statements
         self, url: str, body: str, headers: dict[str, str | bytes]
-    ) -> bool:  # pylint: disable=too-many-statements
+    ) -> bool:
         if not self._circuit_breaker.allow_request():
             logger.warning(
                 "Circuit breaker is OPEN \u2014 skipping POST to %s. %d total requests rejected so far.",

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -201,9 +201,7 @@ class _Agent365Exporter(SpanExporter):
 
     # ------------- SpanExporter API -----------------
 
-    def _resolve_token(
-        self, agent_id: str, tenant_id: str, activities: list[ReadableSpan]
-    ) -> Optional[str]:
+    def _resolve_token(self, agent_id: str, tenant_id: str, activities: list[ReadableSpan]) -> Optional[str]:
         """Resolve auth token, preferring contextual_token_resolver when set."""
         if self._contextual_token_resolver is not None:
             agentic_user_id: Optional[str] = None
@@ -365,7 +363,9 @@ class _Agent365Exporter(SpanExporter):
             return text[:max_length] + "..."
         return text
 
-    def _post_with_retries(self, url: str, body: str, headers: dict[str, str | bytes]) -> bool:
+    def _post_with_retries(
+        self, url: str, body: str, headers: dict[str, str | bytes]
+    ) -> bool:  # pylint: disable=too-many-statements
         if not self._circuit_breaker.allow_request():
             logger.warning(
                 "Circuit breaker is OPEN \u2014 skipping POST to %s. %d total requests rejected so far.",
@@ -378,12 +378,21 @@ class _Agent365Exporter(SpanExporter):
         # import graph for non-distro consumers.
         from urllib.parse import urlparse
         from microsoft.opentelemetry._sdkstats._constants import ENDPOINT_A365
-        from microsoft.opentelemetry._sdkstats._utils import record_success
+        from microsoft.opentelemetry._sdkstats._utils import (
+            THROTTLE_STATUS_CODES,
+            record_duration,
+            record_exception,
+            record_failure,
+            record_retry,
+            record_success,
+            record_throttle,
+        )
 
         host = urlparse(url).hostname or url
         record_a365_sdkstats = self.record_sdkstats
 
         for attempt in range(DEFAULT_MAX_RETRIES + 1):
+            start_time = time.time()
             try:
                 resp = self._session.post(
                     url,
@@ -391,6 +400,8 @@ class _Agent365Exporter(SpanExporter):
                     headers=headers,
                     timeout=DEFAULT_HTTP_TIMEOUT_SECONDS,
                 )
+                if record_a365_sdkstats:
+                    record_duration(ENDPOINT_A365, host, time.time() - start_time)
 
                 correlation_id = resp.headers.get("x-ms-correlation-id") or resp.headers.get("request-id") or "N/A"
 
@@ -412,11 +423,18 @@ class _Agent365Exporter(SpanExporter):
                 if resp.status_code in (408, 429) or 500 <= resp.status_code < 600:
                     retry_after = parse_retry_after(resp.headers)
                     if attempt < DEFAULT_MAX_RETRIES:
+                        if record_a365_sdkstats:
+                            record_retry(ENDPOINT_A365, host, resp.status_code)
                         if retry_after is not None:
                             time.sleep(min(retry_after, 60.0))
                         else:
                             time.sleep(0.5 * (2**attempt))
                         continue
+                    if record_a365_sdkstats:
+                        if resp.status_code in THROTTLE_STATUS_CODES:
+                            record_throttle(ENDPOINT_A365, host, resp.status_code)
+                        else:
+                            record_failure(ENDPOINT_A365, host, resp.status_code)
                     logger.error(
                         "HTTP %d final failure after %d attempts. Correlation ID: %s. Response: %s",
                         resp.status_code,
@@ -426,6 +444,11 @@ class _Agent365Exporter(SpanExporter):
                     )
                     self._circuit_breaker.record_failure()
                 else:
+                    if record_a365_sdkstats:
+                        if resp.status_code in THROTTLE_STATUS_CODES:
+                            record_throttle(ENDPOINT_A365, host, resp.status_code)
+                        else:
+                            record_failure(ENDPOINT_A365, host, resp.status_code)
                     logger.error(
                         "HTTP %d non-retryable error. Correlation ID: %s. Response: %s. "
                         "WWW-Authenticate: %s. Response headers: %s",
@@ -438,6 +461,9 @@ class _Agent365Exporter(SpanExporter):
                 return False
 
             except requests.RequestException as e:
+                if record_a365_sdkstats:
+                    record_duration(ENDPOINT_A365, host, time.time() - start_time)
+                    record_exception(ENDPOINT_A365, host, type(e).__name__)
                 if attempt < DEFAULT_MAX_RETRIES:
                     time.sleep(0.5 * (2**attempt))
                     continue

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -400,8 +400,6 @@ class _Agent365Exporter(SpanExporter):
                     headers=headers,
                     timeout=DEFAULT_HTTP_TIMEOUT_SECONDS,
                 )
-                if record_a365_sdkstats:
-                    record_duration(ENDPOINT_A365, host, time.time() - start_time)
 
                 correlation_id = resp.headers.get("x-ms-correlation-id") or resp.headers.get("request-id") or "N/A"
 
@@ -462,7 +460,6 @@ class _Agent365Exporter(SpanExporter):
 
             except requests.RequestException as e:
                 if record_a365_sdkstats:
-                    record_duration(ENDPOINT_A365, host, time.time() - start_time)
                     record_exception(ENDPOINT_A365, host, type(e).__name__)
                 if attempt < DEFAULT_MAX_RETRIES:
                     time.sleep(0.5 * (2**attempt))
@@ -470,6 +467,10 @@ class _Agent365Exporter(SpanExporter):
                 logger.error("Request failed after %d attempts: %s", DEFAULT_MAX_RETRIES + 1, e)
                 self._circuit_breaker.record_failure()
                 return False
+            finally:
+                # Record duration for every status
+                if record_a365_sdkstats:
+                    record_duration(ENDPOINT_A365, host, time.time() - start_time)
         return False  # pragma: no cover
 
     # ------------- Payload mapping ------------------

--- a/tests/a365/test_exporter.py
+++ b/tests/a365/test_exporter.py
@@ -358,7 +358,15 @@ class TestNetworkStatsbeatHook(unittest.TestCase):
         exporter._session.post.return_value = _make_response(200)
         ok = exporter._post_with_retries(self.URL, "{}", {})
         self.assertTrue(ok)
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {(self.ENDPOINT, self.HOST,): 1})
+        self.assertEqual(
+            drain(REQUEST_SUCCESS_NAME),
+            {
+                (
+                    self.ENDPOINT,
+                    self.HOST,
+                ): 1
+            },
+        )
         exporter.shutdown()
 
     @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
@@ -381,6 +389,171 @@ class TestNetworkStatsbeatHook(unittest.TestCase):
         exporter._session.post.return_value = _make_response(200)
         exporter._post_with_retries(self.URL, "{}", {})
         self.assertEqual(drain(REQUEST_SUCCESS_NAME), {})
+        exporter.shutdown()
+
+    # ------- duration / failure / retry / throttle / exception -------
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_success_records_duration(self, _enabled):
+        from microsoft.opentelemetry._sdkstats._utils import REQUEST_DURATION_NAME, drain
+
+        exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+        exporter._session = MagicMock()
+        exporter._session.post.return_value = _make_response(200)
+        exporter._post_with_retries(self.URL, "{}", {})
+
+        snap = drain(REQUEST_DURATION_NAME)
+        self.assertEqual(set(snap.keys()), {(self.ENDPOINT, self.HOST)})
+        total_seconds, count = snap[(self.ENDPOINT, self.HOST)]
+        self.assertEqual(count, 1)
+        self.assertGreaterEqual(total_seconds, 0)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_non_retryable_status_records_failure(self, _enabled):
+        from microsoft.opentelemetry._sdkstats._utils import REQUEST_FAILURE_NAME, drain
+
+        exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+        exporter._session = MagicMock()
+        exporter._session.post.return_value = _make_response(401)
+        exporter._post_with_retries(self.URL, "{}", {})
+        self.assertEqual(
+            drain(REQUEST_FAILURE_NAME),
+            {(self.ENDPOINT, self.HOST, 401): 1},
+        )
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_non_retryable_throttle_status_records_throttle(self, _enabled):
+        from microsoft.opentelemetry._sdkstats._utils import REQUEST_THROTTLE_NAME, drain
+
+        exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+        exporter._session = MagicMock()
+        exporter._session.post.return_value = _make_response(402)
+        exporter._post_with_retries(self.URL, "{}", {})
+        self.assertEqual(
+            drain(REQUEST_THROTTLE_NAME),
+            {(self.ENDPOINT, self.HOST, 402): 1},
+        )
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_retryable_then_success_records_retry_and_success(self, _enabled):
+        from microsoft.opentelemetry._sdkstats._utils import (
+            REQUEST_RETRY_NAME,
+            REQUEST_SUCCESS_NAME,
+            drain,
+        )
+
+        with patch(
+            "microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep",
+            return_value=None,
+        ):
+            exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+            exporter._session = MagicMock()
+            exporter._session.post.side_effect = [
+                _make_response(503),
+                _make_response(200),
+            ]
+            ok = exporter._post_with_retries(self.URL, "{}", {})
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            drain(REQUEST_RETRY_NAME),
+            {(self.ENDPOINT, self.HOST, 503): 1},
+        )
+        self.assertEqual(
+            drain(REQUEST_SUCCESS_NAME),
+            {(self.ENDPOINT, self.HOST): 1},
+        )
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_retryable_final_failure_records_failure(self, _enabled):
+        """All retries exhausted with a 5xx → record_failure (not throttle)."""
+        from microsoft.opentelemetry._sdkstats._utils import (
+            REQUEST_FAILURE_NAME,
+            REQUEST_RETRY_NAME,
+            drain,
+        )
+
+        with patch(
+            "microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep",
+            return_value=None,
+        ):
+            exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+            exporter._session = MagicMock()
+            exporter._session.post.return_value = _make_response(503)
+            ok = exporter._post_with_retries(self.URL, "{}", {})
+
+        self.assertFalse(ok)
+        # 3 retries (each leading to another attempt) + 1 final failed attempt
+        self.assertEqual(
+            drain(REQUEST_RETRY_NAME),
+            {(self.ENDPOINT, self.HOST, 503): 3},
+        )
+        self.assertEqual(
+            drain(REQUEST_FAILURE_NAME),
+            {(self.ENDPOINT, self.HOST, 503): 1},
+        )
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=True)
+    def test_request_exception_records_exception_and_duration(self, _enabled):
+        import requests
+
+        from microsoft.opentelemetry._sdkstats._utils import (
+            REQUEST_DURATION_NAME,
+            REQUEST_EXCEPTION_NAME,
+            drain,
+        )
+
+        with patch(
+            "microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep",
+            return_value=None,
+        ):
+            exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+            exporter._session = MagicMock()
+            exporter._session.post.side_effect = requests.ConnectionError("boom")
+            ok = exporter._post_with_retries(self.URL, "{}", {})
+
+        self.assertFalse(ok)
+        # record_exception fires on every attempt (4 = 1 initial + 3 retries)
+        self.assertEqual(
+            drain(REQUEST_EXCEPTION_NAME),
+            {(self.ENDPOINT, self.HOST, "ConnectionError"): 4},
+        )
+        # record_duration likewise fires on every attempt
+        snap = drain(REQUEST_DURATION_NAME)
+        self.assertEqual(set(snap.keys()), {(self.ENDPOINT, self.HOST)})
+        _total, count = snap[(self.ENDPOINT, self.HOST)]
+        self.assertEqual(count, 4)
+        exporter.shutdown()
+
+    @patch("microsoft.opentelemetry.a365.core.exporters.agent365_exporter.is_sdkstats_enabled", return_value=False)
+    def test_disabled_records_no_metrics(self, _enabled):
+        """When sdkstats is disabled, none of the new helpers fire."""
+        from microsoft.opentelemetry._sdkstats._utils import (
+            REQUEST_DURATION_NAME,
+            REQUEST_FAILURE_NAME,
+            REQUEST_RETRY_NAME,
+            REQUEST_THROTTLE_NAME,
+            drain,
+        )
+
+        with patch(
+            "microsoft.opentelemetry.a365.core.exporters.agent365_exporter.time.sleep",
+            return_value=None,
+        ):
+            exporter = _Agent365Exporter(token_resolver=lambda a, t: "token")
+            exporter._session = MagicMock()
+            exporter._session.post.return_value = _make_response(503)
+            exporter._post_with_retries(self.URL, "{}", {})
+
+        self.assertEqual(drain(REQUEST_DURATION_NAME), {})
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {})
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {})
+        self.assertEqual(drain(REQUEST_THROTTLE_NAME), {})
         exporter.shutdown()
 
 

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -32,9 +32,20 @@ from microsoft.opentelemetry._sdkstats._state import (
     set_sdkstats_shutdown,
 )
 from microsoft.opentelemetry._sdkstats._utils import (
+    REQUEST_DURATION_NAME,
+    REQUEST_EXCEPTION_NAME,
+    REQUEST_FAILURE_NAME,
+    REQUEST_RETRY_NAME,
     REQUEST_SUCCESS_NAME,
+    REQUEST_THROTTLE_NAME,
+    THROTTLE_STATUS_CODES,
     drain,
+    record_duration,
+    record_exception,
+    record_failure,
+    record_retry,
     record_success,
+    record_throttle,
     reset_all,
 )
 from microsoft.opentelemetry._sdkstats._otlp_wrapper import (
@@ -377,6 +388,295 @@ class TestObserveRequestSuccessCount(unittest.TestCase):
         self.assertEqual(obs, [])
 
 
+class TestRecordHelpers(unittest.TestCase):
+    """Verify each ``record_*`` helper bumps the correct bucket / key shape."""
+
+    def setUp(self):
+        _reset_state()
+
+    def test_record_duration_accumulates_sum_and_count(self):
+        record_duration("a365", "a.example", 0.1)
+        record_duration("a365", "a.example", 0.4)
+        record_duration("otlp", "o.example", 0.2)
+
+        snap = drain(REQUEST_DURATION_NAME)
+        self.assertEqual(set(snap.keys()), {("a365", "a.example"), ("otlp", "o.example")})
+
+        a_sum, a_count = snap[("a365", "a.example")]
+        self.assertAlmostEqual(a_sum, 0.5)
+        self.assertEqual(a_count, 2)
+
+        o_sum, o_count = snap[("otlp", "o.example")]
+        self.assertAlmostEqual(o_sum, 0.2)
+        self.assertEqual(o_count, 1)
+
+    def test_record_failure_keys_include_int_status_code(self):
+        record_failure("a365", "a.example", 401)
+        record_failure("a365", "a.example", 401)
+        record_failure("a365", "a.example", 403)
+
+        self.assertEqual(
+            drain(REQUEST_FAILURE_NAME),
+            {("a365", "a.example", 401): 2, ("a365", "a.example", 403): 1},
+        )
+
+    def test_record_retry_keys_include_int_status_code(self):
+        record_retry("a365", "a.example", 429)
+        record_retry("a365", "a.example", 503)
+
+        self.assertEqual(
+            drain(REQUEST_RETRY_NAME),
+            {("a365", "a.example", 429): 1, ("a365", "a.example", 503): 1},
+        )
+
+    def test_record_throttle_keys_include_int_status_code(self):
+        record_throttle("a365", "a.example", 402)
+        record_throttle("a365", "a.example", 439)
+
+        self.assertEqual(
+            drain(REQUEST_THROTTLE_NAME),
+            {("a365", "a.example", 402): 1, ("a365", "a.example", 439): 1},
+        )
+
+    def test_record_exception_keys_include_exception_type(self):
+        record_exception("a365", "a.example", "ConnectionError")
+        record_exception("a365", "a.example", "ConnectionError")
+        record_exception("a365", "a.example", "Timeout")
+
+        self.assertEqual(
+            drain(REQUEST_EXCEPTION_NAME),
+            {
+                ("a365", "a.example", "ConnectionError"): 2,
+                ("a365", "a.example", "Timeout"): 1,
+            },
+        )
+
+    def test_throttle_status_codes_match_upstream(self):
+        # Upstream owns this list; the distro re-exports it.  Guard against
+        # an accidental local override.
+        from azure.monitor.opentelemetry.exporter._constants import (
+            _THROTTLE_STATUS_CODES,
+        )
+
+        self.assertEqual(THROTTLE_STATUS_CODES, _THROTTLE_STATUS_CODES)
+
+
+class TestObserveRequestDuration(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+
+    def test_empty_when_no_samples(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_duration,
+        )
+
+        self.assertEqual(list(_observe_request_duration(MagicMock())), [])
+
+    def test_emits_average_in_milliseconds(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_duration,
+        )
+
+        record_duration("a365", "a.example", 0.1)  # 100 ms
+        record_duration("a365", "a.example", 0.3)  # 300 ms — avg should be 200 ms
+
+        obs = list(_observe_request_duration(MagicMock()))
+        self.assertEqual(len(obs), 1)
+        o = obs[0]
+        assert o.attributes is not None
+        self.assertEqual(o.attributes["endpoint"], "a365")
+        self.assertEqual(o.attributes["host"], "a.example")
+        self.assertAlmostEqual(o.value, 200.0)
+
+    def test_callback_drains_state(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_duration,
+        )
+
+        record_duration("a365", "a.example", 0.1)
+        list(_observe_request_duration(MagicMock()))
+        self.assertEqual(list(_observe_request_duration(MagicMock())), [])
+
+
+class TestObserveRequestFailureCount(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+
+    def test_empty_when_no_failures(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_failure_count,
+        )
+
+        self.assertEqual(list(_observe_request_failure_count(MagicMock())), [])
+
+    def test_emits_one_per_status(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_failure_count,
+        )
+
+        record_failure("a365", "a.example", 401)
+        record_failure("a365", "a.example", 401)
+        record_failure("a365", "a.example", 403)
+
+        obs = list(_observe_request_failure_count(MagicMock()))
+        self.assertEqual(len(obs), 2)
+        by_status = {}
+        for o in obs:
+            assert o.attributes is not None
+            self.assertEqual(o.attributes["endpoint"], "a365")
+            self.assertEqual(o.attributes["host"], "a.example")
+            by_status[o.attributes["statusCode"]] = o.value
+        self.assertEqual(by_status, {401: 2, 403: 1})
+
+    def test_callback_drains_state(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_failure_count,
+        )
+
+        record_failure("a365", "a.example", 401)
+        list(_observe_request_failure_count(MagicMock()))
+        self.assertEqual(list(_observe_request_failure_count(MagicMock())), [])
+
+
+class TestObserveRequestRetryCount(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+
+    def test_emits_one_per_status(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_retry_count,
+        )
+
+        record_retry("a365", "a.example", 429)
+        record_retry("a365", "a.example", 503)
+        record_retry("a365", "a.example", 503)
+
+        obs = list(_observe_request_retry_count(MagicMock()))
+        self.assertEqual(len(obs), 2)
+        by_status = {o.attributes["statusCode"]: o.value for o in obs if o.attributes}
+        self.assertEqual(by_status, {429: 1, 503: 2})
+
+    def test_callback_drains_state(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_retry_count,
+        )
+
+        record_retry("a365", "a.example", 429)
+        list(_observe_request_retry_count(MagicMock()))
+        self.assertEqual(list(_observe_request_retry_count(MagicMock())), [])
+
+
+class TestObserveRequestThrottleCount(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+
+    def test_emits_one_per_status(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_throttle_count,
+        )
+
+        record_throttle("a365", "a.example", 402)
+        record_throttle("a365", "a.example", 439)
+
+        obs = list(_observe_request_throttle_count(MagicMock()))
+        self.assertEqual(len(obs), 2)
+        by_status = {o.attributes["statusCode"]: o.value for o in obs if o.attributes}
+        self.assertEqual(by_status, {402: 1, 439: 1})
+
+    def test_callback_drains_state(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_throttle_count,
+        )
+
+        record_throttle("a365", "a.example", 402)
+        list(_observe_request_throttle_count(MagicMock()))
+        self.assertEqual(list(_observe_request_throttle_count(MagicMock())), [])
+
+
+class TestObserveRequestExceptionCount(unittest.TestCase):
+    def setUp(self):
+        _reset_state()
+
+    def test_emits_one_per_exception_type(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_exception_count,
+        )
+
+        record_exception("a365", "a.example", "ConnectionError")
+        record_exception("a365", "a.example", "ConnectionError")
+        record_exception("a365", "a.example", "Timeout")
+
+        obs = list(_observe_request_exception_count(MagicMock()))
+        self.assertEqual(len(obs), 2)
+        by_type = {o.attributes["exceptionType"]: o.value for o in obs if o.attributes}
+        self.assertEqual(by_type, {"ConnectionError": 2, "Timeout": 1})
+
+    def test_callback_drains_state(self):
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            _observe_request_exception_count,
+        )
+
+        record_exception("a365", "a.example", "ConnectionError")
+        list(_observe_request_exception_count(MagicMock()))
+        self.assertEqual(list(_observe_request_exception_count(MagicMock())), [])
+
+
+class TestRegisterNetworkGaugesAttachesAllSix(unittest.TestCase):
+    """``register_network_gauges`` must attach a callback to every upstream
+    network statsbeat gauge, not just success."""
+
+    def setUp(self):
+        _reset_state()
+        _reset_upstream_singleton()
+        _reset_network_metrics_guard()
+
+    def tearDown(self):
+        _reset_upstream_singleton()
+        _reset_network_metrics_guard()
+
+    def test_attaches_to_all_six_gauges(self):
+        from azure.monitor.opentelemetry.exporter.statsbeat._manager import (
+            StatsbeatManager,
+        )
+        from microsoft.opentelemetry._sdkstats._config import (
+            _build_default_sdkstats_config,
+        )
+        from microsoft.opentelemetry._sdkstats._network_metrics import (
+            register_network_gauges,
+        )
+
+        config = _build_default_sdkstats_config()
+        self.assertTrue(StatsbeatManager().initialize(config))
+
+        # The six upstream gauges the distro must attach to.
+        gauge_attrs = [
+            "_success_count",
+            "_average_duration",
+            "_failure_count",
+            "_retry_count",
+            "_throttle_count",
+            "_exception_count",
+        ]
+
+        # Snapshot pre-registration callback counts so we can assert exactly
+        # one new callback per gauge.
+        metrics = StatsbeatManager()._metrics  # pylint: disable=protected-access
+        assert metrics is not None
+        before = {
+            name: len(getattr(metrics, name)._callbacks) for name in gauge_attrs  # pylint: disable=protected-access
+        }
+
+        self.assertTrue(register_network_gauges())
+
+        for name in gauge_attrs:
+            after = len(getattr(metrics, name)._callbacks)  # pylint: disable=protected-access
+            self.assertEqual(
+                after,
+                before[name] + 1,
+                f"Expected one distro callback appended to {name}",
+            )
+
+
 class TestInitializeSdkStats(unittest.TestCase):
     """Tests for _initialize_sdkstats in _distro.py."""
 
@@ -395,9 +695,7 @@ class TestInitializeSdkStats(unittest.TestCase):
 
         os.environ[_SDKSTATS_DISABLED_ENV] = "true"
         try:
-            with patch(
-                "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
-            ) as mock_cls:
+            with patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager") as mock_cls:
                 _initialize_sdkstats(enable_azure_monitor=False)
                 mock_cls.assert_not_called()
         finally:
@@ -408,9 +706,7 @@ class TestInitializeSdkStats(unittest.TestCase):
         manager from customer config; the distro must NOT call initialize()."""
         from microsoft.opentelemetry._distro import _initialize_sdkstats
 
-        with patch(
-            "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
-        ) as mock_cls:
+        with patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager") as mock_cls:
             mock_instance = MagicMock()
             mock_cls.return_value = mock_instance
             _initialize_sdkstats(enable_azure_monitor=True)
@@ -419,11 +715,10 @@ class TestInitializeSdkStats(unittest.TestCase):
     def test_standalone_path_initializes_manager_with_default_config(self):
         from microsoft.opentelemetry._distro import _initialize_sdkstats
 
-        with patch(
-            "microsoft.opentelemetry._sdkstats._config._build_default_sdkstats_config"
-        ) as mock_build, patch(
-            "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
-        ) as mock_cls:
+        with (
+            patch("microsoft.opentelemetry._sdkstats._config._build_default_sdkstats_config") as mock_build,
+            patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager") as mock_cls,
+        ):
             fake_config = MagicMock(name="StatsbeatConfig")
             mock_build.return_value = fake_config
             mock_instance = MagicMock()
@@ -437,12 +732,13 @@ class TestInitializeSdkStats(unittest.TestCase):
     def test_standalone_skips_manager_when_config_is_none(self):
         from microsoft.opentelemetry._distro import _initialize_sdkstats
 
-        with patch(
-            "microsoft.opentelemetry._sdkstats._config._build_default_sdkstats_config",
-            return_value=None,
-        ), patch(
-            "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
-        ) as mock_cls:
+        with (
+            patch(
+                "microsoft.opentelemetry._sdkstats._config._build_default_sdkstats_config",
+                return_value=None,
+            ),
+            patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager") as mock_cls,
+        ):
             mock_instance = MagicMock()
             mock_cls.return_value = mock_instance
             _initialize_sdkstats(enable_azure_monitor=False)
@@ -451,10 +747,9 @@ class TestInitializeSdkStats(unittest.TestCase):
     def test_always_calls_register_network_gauges(self):
         from microsoft.opentelemetry._distro import _initialize_sdkstats
 
-        with patch(
-            "microsoft.opentelemetry._sdkstats._network_metrics.register_network_gauges"
-        ) as mock_register, patch(
-            "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
+        with (
+            patch("microsoft.opentelemetry._sdkstats._network_metrics.register_network_gauges") as mock_register,
+            patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"),
         ):
             _initialize_sdkstats(enable_azure_monitor=True)
             _initialize_sdkstats(enable_azure_monitor=False)
@@ -463,10 +758,9 @@ class TestInitializeSdkStats(unittest.TestCase):
     def test_always_bridges_feature_and_instrumentation_bits(self):
         from microsoft.opentelemetry._distro import _initialize_sdkstats
 
-        with patch(
-            "microsoft.opentelemetry._distro._bridge_sdkstats_to_azure_monitor"
-        ) as mock_bridge, patch(
-            "azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"
+        with (
+            patch("microsoft.opentelemetry._distro._bridge_sdkstats_to_azure_monitor") as mock_bridge,
+            patch("azure.monitor.opentelemetry.exporter.statsbeat._manager.StatsbeatManager"),
         ):
             _initialize_sdkstats(enable_azure_monitor=True)
             _initialize_sdkstats(enable_azure_monitor=False)


### PR DESCRIPTION
Adding the remaining metrics - 

- _REQ_DURATION_NAME_
- _REQ_EXCEPTION_NAME_
- _REQ_FAILURE_NAME_
- _REQ_RETRY_NAME_
- _REQ_THROTTLE_NAME_


Follow up PRs:
- PR for adding these metrics for OTLP exporter
- PR for refactoring the exporter code for the upstream SDKStatsManger for adding the metrics, instead of registering the gauges manually (as pointed out in PR - https://github.com/microsoft/opentelemetry-distro-python/pull/182)