### PR TITLE
Fix token count mismatch in Agents dashboard for nested LangGraph setups

### DIFF
--- a/src/microsoft/opentelemetry/_genai/_langchain/_tracer.py
+++ b/src/microsoft/opentelemetry/_genai/_langchain/_tracer.py
@@ -394,8 +394,8 @@ class LangChainTracer(BaseTracer):  # pylint: disable=too-many-ancestors, too-ma
         """Detect whether a LangChain run should be the top-level agent span."""
         if not self._is_agent_like_chain(run):
             return False
-        # Don't nest agents — if a parent is already an agent, this is internal
-        if run.parent_run_id and run.parent_run_id in self._agent_run_ids:
+        # Don't nest agents — if any ancestor is already an agent, this is internal
+        if self._find_agent_ancestor(run) is not None:
             return False
         return True
 

--- a/tests/langchain/test_tracer.py
+++ b/tests/langchain/test_tracer.py
@@ -160,6 +160,22 @@ class TestIsAgentRun(TestCase):
         run = _make_run(run_type="chain", name="RunnableSequence")
         self.assertFalse(tracer._is_agent_run(run))
 
+    def test_deeply_nested_agent_returns_false(self):
+        """Agent-like chain nested under a non-agent chain whose ancestor is
+        already an agent must NOT be treated as a separate agent.  This
+        prevents token aggregation from splitting across multiple agent
+        spans (see token-count mismatch in multi-agent LangGraph setups)."""
+        tracer, _, _ = _make_tracer()
+        agent_id = uuid4()
+        chain_id = uuid4()
+        tracer._agent_run_ids.add(agent_id)
+        # Intermediate non-agent chain between top-level agent and sub-graph.
+        chain_run = _make_run(run_type="chain", name="node_step", id=chain_id, parent_run_id=agent_id)
+        tracer.run_map[str(chain_id)] = chain_run
+        # Sub-graph whose direct parent is the intermediate chain, not the agent.
+        sub_graph = _make_run(run_type="chain", name="SubAgentGraph", parent_run_id=chain_id)
+        self.assertFalse(tracer._is_agent_run(sub_graph))
+
 
 # ---- Agent name resolution ---------------------------------------------------
 
@@ -760,6 +776,7 @@ class TestContextAttachDetach(TestCase):
             self.assertIs(attach_call_args[0][0], inner_span)
         mock_ctx.attach.assert_called_once()
 
+
 # ---- invoke_agent aggregation fixes (issue #172) -----------------------------
 
 
@@ -1070,9 +1087,7 @@ class TestExtractAgentInputMessagesToolRole(TestCase):
                     "id": ["langchain", "schema", "messages", "AIMessage"],
                     "kwargs": {
                         "content": "",
-                        "tool_calls": [
-                            {"name": "get_weather", "args": {"location": "Paris"}, "id": "tc1"}
-                        ],
+                        "tool_calls": [{"name": "get_weather", "args": {"location": "Paris"}, "id": "tc1"}],
                         "type": "ai",
                     },
                 },
@@ -1086,4 +1101,3 @@ class TestExtractAgentInputMessagesToolRole(TestCase):
         self.assertEqual(tool_part.type, "tool_call_response")
         self.assertEqual(tool_part.id, "tc1")
         self.assertEqual(tool_part.response, "rainy")
-


### PR DESCRIPTION
Problem

In multi-agent LangGraph setups (e.g., graphs with sub-graphs), the Agents dashboard in Azure Monitor shows significantly lower token counts than what appears in the trace spans. For example, a trace showing 6,816 total tokens would only display ~2.2K in the Token Consumption chart.

Root Cause

_is_agent_run() only checked the direct parent when preventing nested agent detection:

    if run.parent_run_id and run.parent_run_id in self._agent_run_ids:

In LangGraph, agent-like sub-graphs are often separated from the top-level agent by intermediate chain nodes:

    TopAgent (agent) -> node_step (chain) -> SubGraph (wrongly detected as agent) -> LLM

Since SubGraph's direct parent is node_step (not in _agent_run_ids), it was incorrectly treated as a separate agent. LLM tokens under it aggregated to SubGraph's bucket instead of the top-level agent. When SubGraph ended, its tokens were discarded -- agent runs don't roll up to parent agents.

Fix

Changed the direct-parent check to walk the full ancestor chain using the existing _find_agent_ancestor() method:

    if self._find_agent_ancestor(run) is not None:
        return False

This ensures any agent-like chain nested anywhere under an existing agent is treated as internal, and all LLM token counts aggregate to the single top-level invoke_agent wrapper span.