### PR TITLE
Add remaining network sdkstats metrics for OTLP

### DIFF
--- a/src/microsoft/opentelemetry/_otlp/handler.py
+++ b/src/microsoft/opentelemetry/_otlp/handler.py
@@ -92,21 +92,24 @@ def create_otlp_components(
     components = OtlpHandlers()
 
     if enable_traces:
-        span_exporter: SpanExporter = OTLPSpanExporter()
         if record_network_sdkstats:
-            span_exporter = _NetworkStatsSpanExporter(span_exporter)
+            span_exporter: SpanExporter = _NetworkStatsSpanExporter()
+        else:
+            span_exporter = OTLPSpanExporter()
         components.span_processor = BatchSpanProcessor(span_exporter)
 
     if enable_metrics:
-        metric_exporter: MetricExporter = OTLPMetricExporter()
         if record_network_sdkstats:
-            metric_exporter = _NetworkStatsMetricExporter(metric_exporter)
+            metric_exporter: MetricExporter = _NetworkStatsMetricExporter()
+        else:
+            metric_exporter = OTLPMetricExporter()
         components.metric_reader = PeriodicExportingMetricReader(metric_exporter)
 
     if enable_logs:
-        log_exporter: LogRecordExporter = OTLPLogExporter()
         if record_network_sdkstats:
-            log_exporter = _NetworkStatsLogExporter(log_exporter)
+            log_exporter: LogRecordExporter = _NetworkStatsLogExporter()
+        else:
+            log_exporter = OTLPLogExporter()
         components.log_record_processor = BatchLogRecordProcessor(log_exporter)
 
     return components

--- a/src/microsoft/opentelemetry/_sdkstats/_constants.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_constants.py
@@ -14,6 +14,7 @@ from azure.monitor.opentelemetry.exporter._constants import (  # type: ignore[im
     _REQ_SUCCESS_NAME,
     _REQ_THROTTLE_NAME,
     _THROTTLE_STATUS_CODES,
+    _RETRYABLE_STATUS_CODES,
 )
 
 REQUEST_DURATION_NAME = _REQ_DURATION_NAME[0]
@@ -24,6 +25,7 @@ REQUEST_SUCCESS_NAME = _REQ_SUCCESS_NAME[0]
 REQUEST_THROTTLE_NAME = _REQ_THROTTLE_NAME[0]
 
 THROTTLE_STATUS_CODES = _THROTTLE_STATUS_CODES
+RETRYABLE_STATUS_CODES = _RETRYABLE_STATUS_CODES
 
 
 # Endpoint type enum values for the ``endpoint`` dimension on network sdkstats

--- a/src/microsoft/opentelemetry/_sdkstats/_constants.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_constants.py
@@ -14,7 +14,6 @@ from azure.monitor.opentelemetry.exporter._constants import (  # type: ignore[im
     _REQ_SUCCESS_NAME,
     _REQ_THROTTLE_NAME,
     _THROTTLE_STATUS_CODES,
-    _RETRYABLE_STATUS_CODES,
 )
 
 REQUEST_DURATION_NAME = _REQ_DURATION_NAME[0]
@@ -25,7 +24,12 @@ REQUEST_SUCCESS_NAME = _REQ_SUCCESS_NAME[0]
 REQUEST_THROTTLE_NAME = _REQ_THROTTLE_NAME[0]
 
 THROTTLE_STATUS_CODES = _THROTTLE_STATUS_CODES
-RETRYABLE_STATUS_CODES = _RETRYABLE_STATUS_CODES
+OTLP_RETRYABLE_STATUS_CODES = (
+    429,  # Too Many Requests
+    502,  # Bad Gateway
+    503,  # Service Unavailable
+    504,  # Gateway Timeout
+)
 
 
 # Endpoint type enum values for the ``endpoint`` dimension on network sdkstats

--- a/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_network_metrics.py
@@ -22,15 +22,15 @@ from typing import Iterable, List
 
 from opentelemetry.metrics import CallbackOptions, Observation
 
-from microsoft.opentelemetry._sdkstats._utils import (
+from microsoft.opentelemetry._sdkstats._constants import (
     REQUEST_DURATION_NAME,
     REQUEST_EXCEPTION_NAME,
     REQUEST_FAILURE_NAME,
     REQUEST_RETRY_NAME,
     REQUEST_SUCCESS_NAME,
     REQUEST_THROTTLE_NAME,
-    drain,
 )
+from microsoft.opentelemetry._sdkstats._utils import drain
 
 try:
     from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (

--- a/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
@@ -22,7 +22,7 @@ actual HTTP status code:
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -72,7 +72,7 @@ def _classify(host: str, response: requests.Response) -> None:
 def _record_attempt(
     host: str,
     start: float,
-    super_export,
+    super_export: Callable[[bytes, Optional[float]], requests.Response],
     serialized_data: bytes,
     timeout_sec: Optional[float],
 ) -> requests.Response:
@@ -83,7 +83,7 @@ def _record_attempt(
     """
     try:
         try:
-            response = super_export(serialized_data, timeout_sec)
+            response: requests.Response = super_export(serialized_data, timeout_sec)
         except Exception as exc:  # noqa: BLE001
             record_exception(ENDPOINT_OTLP, host, type(exc).__name__)
             raise

--- a/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
@@ -4,25 +4,41 @@
 # license information.
 # --------------------------------------------------------------------------
 
-"""Network statsbeat wrappers for OTLP exporters.
+"""Network statsbeat wrappers for OTLP HTTP exporters.
 
-The upstream OTLP exporters do not expose HTTP status codes — only the
-``ExportResult`` enum.  These wrappers capture the SUCCESS signal so the
-network statsbeat pipeline can record success/failures/retries per
-endpoint.
+These classes subclass the upstream ``opentelemetry-exporter-otlp-proto-http``
+exporters and override ``_export()`` -- the per-HTTP-attempt seam that
+returns a ``requests.Response`` -- so we can classify each attempt by its
+actual HTTP status code:
+
+* 2xx                                 -> ``request_success_count``
+* 402, 439 (throttle)                 -> ``request_throttle_count``
+* 408, 429, 500, 502, 503, 504 (retry) -> ``request_retry_count``
+* other 4xx / 5xx                     -> ``request_failure_count``
+* network/SSL/serialization exception -> ``request_exception_count``
+
 """
 
 from __future__ import annotations
 
-from typing import Any
+import time
+from typing import Any, Optional
 from urllib.parse import urlparse
 
-from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
-from opentelemetry.sdk.metrics.export import MetricExporter, MetricExportResult, MetricsData
-from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+import requests
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-from microsoft.opentelemetry._sdkstats._constants import ENDPOINT_OTLP
-from microsoft.opentelemetry._sdkstats._utils import record_success
+from microsoft.opentelemetry._sdkstats._constants import ENDPOINT_OTLP, THROTTLE_STATUS_CODES, RETRYABLE_STATUS_CODES
+from microsoft.opentelemetry._sdkstats._utils import (
+    record_duration,
+    record_exception,
+    record_failure,
+    record_retry,
+    record_success,
+    record_throttle,
+)
 
 
 def _endpoint_host(exporter: Any) -> str:
@@ -35,70 +51,92 @@ def _endpoint_host(exporter: Any) -> str:
         return raw
 
 
-class _NetworkStatsSpanExporter(SpanExporter):
-    """Span exporter decorator that records ``request_success_count``."""
-
-    def __init__(self, inner: SpanExporter) -> None:
-        self._inner = inner
-        self._host = _endpoint_host(inner)
-
-    def export(self, spans: Any) -> SpanExportResult:  # type: ignore[override]
-        result = self._inner.export(spans)
-        if result == SpanExportResult.SUCCESS:
-            record_success(ENDPOINT_OTLP, self._host)
-        return result
-
-    def shutdown(self) -> None:
-        self._inner.shutdown()
-
-    def force_flush(self, timeout_millis: int = 30_000) -> bool:
-        return self._inner.force_flush(timeout_millis)
+def _classify(host: str, response: requests.Response) -> None:
+    """Record one success/throttle/retry/failure based on HTTP status."""
+    code = response.status_code
+    if 200 <= code < 300:
+        record_success(ENDPOINT_OTLP, host)
+    elif code in THROTTLE_STATUS_CODES:
+        record_throttle(ENDPOINT_OTLP, host, code)
+    elif code in RETRYABLE_STATUS_CODES:
+        record_retry(ENDPOINT_OTLP, host, code)
+    else:
+        record_failure(ENDPOINT_OTLP, host, code)
 
 
-class _NetworkStatsMetricExporter(MetricExporter):
-    """Metric exporter decorator that records ``request_success_count``."""
+def _record_attempt(
+    host: str,
+    start: float,
+    super_export,
+    serialized_data: bytes,
+    timeout_sec: Optional[float],
+) -> requests.Response:
+    """Shared per-attempt body: classify outcome, record duration in finally.
 
-    def __init__(self, inner: MetricExporter) -> None:
-        super().__init__(
-            preferred_temporality=getattr(inner, "_preferred_temporality", None),
-            preferred_aggregation=getattr(inner, "_preferred_aggregation", None),
-        )
-        self._inner = inner
-        self._host = _endpoint_host(inner)
+    ``super_export`` is the bound ``super()._export`` of the calling
+    subclass, so all three signal exporters can share this body.
+    """
+    try:
+        try:
+            response = super_export(serialized_data, timeout_sec)
+        except Exception as exc:  # noqa: BLE001
+            record_exception(ENDPOINT_OTLP, host, type(exc).__name__)
+            raise
+        _classify(host, response)
+        return response
+    finally:
+        record_duration(ENDPOINT_OTLP, host, time.time() - start)
 
-    def export(  # type: ignore[override]
+
+class _NetworkStatsSpanExporter(OTLPSpanExporter):
+    """OTLP span exporter that records per-attempt network statsbeat."""
+
+    def _export(  # type: ignore[override]
         self,
-        metrics_data: MetricsData,
-        timeout_millis: float = 10_000,
-        **kwargs: Any,
-    ) -> MetricExportResult:
-        result = self._inner.export(metrics_data, timeout_millis, **kwargs)
-        if result == MetricExportResult.SUCCESS:
-            record_success(ENDPOINT_OTLP, self._host)
-        return result
-
-    def force_flush(self, timeout_millis: float = 10_000) -> bool:  # type: ignore[override]
-        return self._inner.force_flush(timeout_millis)
-
-    def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:  # type: ignore[override]
-        self._inner.shutdown(timeout_millis, **kwargs)
+        serialized_data: bytes,
+        timeout_sec: Optional[float] = None,
+    ) -> requests.Response:
+        return _record_attempt(
+            _endpoint_host(self),
+            time.time(),
+            super()._export,
+            serialized_data,
+            timeout_sec,
+        )
 
 
-class _NetworkStatsLogExporter(LogRecordExporter):
-    """Log exporter decorator that records ``request_success_count``."""
+class _NetworkStatsMetricExporter(OTLPMetricExporter):
+    """OTLP metric exporter that records per-attempt network statsbeat."""
 
-    def __init__(self, inner: LogRecordExporter) -> None:
-        self._inner = inner
-        self._host = _endpoint_host(inner)
+    def _export(  # type: ignore[override]
+        self,
+        serialized_data: bytes,
+        timeout_sec: Optional[float] = None,
+    ) -> requests.Response:
+        return _record_attempt(
+            _endpoint_host(self),
+            time.time(),
+            super()._export,
+            serialized_data,
+            timeout_sec,
+        )
 
-    def export(self, batch: Any) -> LogRecordExportResult:  # type: ignore[override]
-        result = self._inner.export(batch)
-        if result == LogRecordExportResult.SUCCESS:
-            record_success(ENDPOINT_OTLP, self._host)
-        return result
 
-    def shutdown(self) -> None:
-        self._inner.shutdown()
+class _NetworkStatsLogExporter(OTLPLogExporter):
+    """OTLP log exporter that records per-attempt network statsbeat."""
+
+    def _export(  # type: ignore[override]
+        self,
+        serialized_data: bytes,
+        timeout_sec: Optional[float] = None,
+    ) -> requests.Response:
+        return _record_attempt(
+            _endpoint_host(self),
+            time.time(),
+            super()._export,
+            serialized_data,
+            timeout_sec,
+        )
 
 
 __all__ = [

--- a/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
@@ -12,8 +12,7 @@ returns a ``requests.Response`` -- so we can classify each attempt by its
 actual HTTP status code:
 
 * 2xx                                 -> ``request_success_count``
-* 402, 439 (throttle)                 -> ``request_throttle_count``
-* 408, 429, 500, 502, 503, 504 (retry) -> ``request_retry_count``
+* 429, 502, 503, 504 (retry) -> ``request_retry_count``
 * other 4xx / 5xx                     -> ``request_failure_count``
 * network/SSL/serialization exception -> ``request_exception_count``
 
@@ -31,9 +30,8 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 from microsoft.opentelemetry._sdkstats._constants import (
-    ENDPOINT_OTLP, 
-    THROTTLE_STATUS_CODES, 
-    RETRYABLE_STATUS_CODES,
+    ENDPOINT_OTLP,
+    OTLP_RETRYABLE_STATUS_CODES,
 )
 
 from microsoft.opentelemetry._sdkstats._utils import (
@@ -42,7 +40,6 @@ from microsoft.opentelemetry._sdkstats._utils import (
     record_failure,
     record_retry,
     record_success,
-    record_throttle,
 )
 
 
@@ -57,13 +54,11 @@ def _endpoint_host(exporter: Any) -> str:
 
 
 def _classify(host: str, response: requests.Response) -> None:
-    """Record one success/throttle/retry/failure based on HTTP status."""
+    """Record per-attempt outcome based on HTTP status."""
     code = response.status_code
     if 200 <= code < 300:
         record_success(ENDPOINT_OTLP, host)
-    elif code in THROTTLE_STATUS_CODES:
-        record_throttle(ENDPOINT_OTLP, host, code)
-    elif code in RETRYABLE_STATUS_CODES:
+    elif code in OTLP_RETRYABLE_STATUS_CODES:
         record_retry(ENDPOINT_OTLP, host, code)
     else:
         record_failure(ENDPOINT_OTLP, host, code)

--- a/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_otlp_wrapper.py
@@ -30,7 +30,12 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-from microsoft.opentelemetry._sdkstats._constants import ENDPOINT_OTLP, THROTTLE_STATUS_CODES, RETRYABLE_STATUS_CODES
+from microsoft.opentelemetry._sdkstats._constants import (
+    ENDPOINT_OTLP, 
+    THROTTLE_STATUS_CODES, 
+    RETRYABLE_STATUS_CODES,
+)
+
 from microsoft.opentelemetry._sdkstats._utils import (
     record_duration,
     record_exception,

--- a/src/microsoft/opentelemetry/_sdkstats/_utils.py
+++ b/src/microsoft/opentelemetry/_sdkstats/_utils.py
@@ -18,7 +18,6 @@ from microsoft.opentelemetry._sdkstats._constants import (
     REQUEST_RETRY_NAME,
     REQUEST_SUCCESS_NAME,
     REQUEST_THROTTLE_NAME,
-    THROTTLE_STATUS_CODES,
 )
 
 # ===========================================================================
@@ -58,13 +57,6 @@ def update_global_state_instrumentation_bits(instrumentation_bits: int) -> None:
 # export interval.
 
 __all__ = [
-    "THROTTLE_STATUS_CODES",
-    "REQUEST_SUCCESS_NAME",
-    "REQUEST_DURATION_NAME",
-    "REQUEST_FAILURE_NAME",
-    "REQUEST_RETRY_NAME",
-    "REQUEST_THROTTLE_NAME",
-    "REQUEST_EXCEPTION_NAME",
     "record_success",
     "record_duration",
     "record_failure",

--- a/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
+++ b/src/microsoft/opentelemetry/a365/core/exporters/agent365_exporter.py
@@ -377,9 +377,11 @@ class _Agent365Exporter(SpanExporter):
         # Local imports to avoid pulling sdkstats into the exporter module's
         # import graph for non-distro consumers.
         from urllib.parse import urlparse
-        from microsoft.opentelemetry._sdkstats._constants import ENDPOINT_A365
-        from microsoft.opentelemetry._sdkstats._utils import (
+        from microsoft.opentelemetry._sdkstats._constants import (
+            ENDPOINT_A365,
             THROTTLE_STATUS_CODES,
+        )
+        from microsoft.opentelemetry._sdkstats._utils import (
             record_duration,
             record_exception,
             record_failure,

--- a/tests/test_otlp.py
+++ b/tests/test_otlp.py
@@ -273,5 +273,96 @@ class TestOtlpIntegrationWithDistro(unittest.TestCase):
         self.assertIn(otlp_sp, processors)
 
 
+class TestCreateOtlpComponentsWithSdkstats(unittest.TestCase):
+    """Tests for create_otlp_components() when sdkstats network instrumentation is enabled.
+
+    When ``is_sdkstats_enabled()`` returns True, ``create_otlp_components()`` must wire
+    the ``_NetworkStats{Span,Metric,Log}Exporter`` subclasses (instead of the plain
+    OTLP exporters) into the returned processors/readers so that per-HTTP-attempt
+    network statsbeat is recorded.
+    """
+
+    def setUp(self):
+        import sys
+
+        self._saved_modules = {}
+        fake_modules = [
+            "opentelemetry.exporter",
+            "opentelemetry.exporter.otlp",
+            "opentelemetry.exporter.otlp.proto",
+            "opentelemetry.exporter.otlp.proto.http",
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+            "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+            "opentelemetry.exporter.otlp.proto.http._log_exporter",
+        ]
+        for mod in fake_modules:
+            self._saved_modules[mod] = sys.modules.get(mod)
+        _install_fake_otlp_modules()
+
+    def tearDown(self):
+        import sys
+
+        for mod, original in self._saved_modules.items():
+            if original is None:
+                sys.modules.pop(mod, None)
+            else:
+                sys.modules[mod] = original
+
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsLogExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsMetricExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsSpanExporter")
+    @patch("microsoft.opentelemetry._sdkstats.is_sdkstats_enabled", return_value=True)
+    def test_uses_networkstats_exporters_when_sdkstats_enabled(
+        self, mock_enabled, mock_span_cls, mock_metric_cls, mock_log_cls
+    ):
+        """All three signals receive a ``_NetworkStats*Exporter`` instance."""
+        components = create_otlp_components()
+
+        mock_span_cls.assert_called_once_with()
+        mock_metric_cls.assert_called_once_with()
+        mock_log_cls.assert_called_once_with()
+
+        # BatchSpanProcessor stores the exporter as ``span_exporter``.
+        self.assertIs(components.span_processor.span_exporter, mock_span_cls.return_value)
+        # PeriodicExportingMetricReader stores the exporter as ``_exporter``.
+        self.assertIs(components.metric_reader._exporter, mock_metric_cls.return_value)
+        # BatchLogRecordProcessor delegates to an inner ``_batch_processor`` which holds ``_exporter``.
+        self.assertIs(
+            components.log_record_processor._batch_processor._exporter,
+            mock_log_cls.return_value,
+        )
+
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsLogExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsMetricExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsSpanExporter")
+    @patch("microsoft.opentelemetry._sdkstats.is_sdkstats_enabled", return_value=False)
+    def test_uses_plain_otlp_exporters_when_sdkstats_disabled(
+        self, mock_enabled, mock_span_cls, mock_metric_cls, mock_log_cls
+    ):
+        """When sdkstats is disabled, the ``_NetworkStats*Exporter`` classes are not used."""
+        create_otlp_components()
+
+        mock_span_cls.assert_not_called()
+        mock_metric_cls.assert_not_called()
+        mock_log_cls.assert_not_called()
+
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsLogExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsMetricExporter")
+    @patch("microsoft.opentelemetry._sdkstats._otlp_wrapper._NetworkStatsSpanExporter")
+    @patch("microsoft.opentelemetry._sdkstats.is_sdkstats_enabled", return_value=True)
+    def test_signal_toggles_respected_with_sdkstats(
+        self, mock_enabled, mock_span_cls, mock_metric_cls, mock_log_cls
+    ):
+        """``enable_*`` flags still gate exporter creation when sdkstats is enabled."""
+        components = create_otlp_components(enable_traces=True, enable_metrics=False, enable_logs=False)
+
+        mock_span_cls.assert_called_once_with()
+        mock_metric_cls.assert_not_called()
+        mock_log_cls.assert_not_called()
+        self.assertIsNotNone(components.span_processor)
+        self.assertIsNone(components.metric_reader)
+        self.assertIsNone(components.log_record_processor)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -31,7 +31,7 @@ from microsoft.opentelemetry._sdkstats._state import (
     set_sdkstats_instrumentation_by_name,
     set_sdkstats_shutdown,
 )
-from microsoft.opentelemetry._sdkstats._utils import (
+from microsoft.opentelemetry._sdkstats._constants import (
     REQUEST_DURATION_NAME,
     REQUEST_EXCEPTION_NAME,
     REQUEST_FAILURE_NAME,
@@ -39,6 +39,8 @@ from microsoft.opentelemetry._sdkstats._utils import (
     REQUEST_SUCCESS_NAME,
     REQUEST_THROTTLE_NAME,
     THROTTLE_STATUS_CODES,
+)
+from microsoft.opentelemetry._sdkstats._utils import (
     drain,
     record_duration,
     record_exception,
@@ -768,86 +770,237 @@ class TestInitializeSdkStats(unittest.TestCase):
 
 
 class TestNetworkStatsExporterWrappers(unittest.TestCase):
-    """Tests for the OTLP NetworkStats* exporter decorators."""
+    """Tests for the OTLP NetworkStats* exporter subclasses.
+
+    These classes subclass the upstream OTLP HTTP exporters and override
+    ``_export()`` -- the per-HTTP-attempt seam.  The tests exercise that
+    override directly with a mocked ``super()._export`` so each HTTP
+    outcome can be classified deterministically without actually
+    speaking HTTP.
+    """
+
+    SPAN_ENDPOINT = "https://otlp.example.com/v1/traces"
+    METRIC_ENDPOINT = "https://otlp.example.com/v1/metrics"
+    LOG_ENDPOINT = "https://otlp.example.com/v1/logs"
+    HOST_KEY = ("otlp", "otlp.example.com")
 
     def setUp(self):
         _reset_state()
 
-    def _inner_span(self, result, endpoint="https://otlp.example.com/v1/traces"):
-        inner = MagicMock()
-        inner._endpoint = endpoint
-        inner.export.return_value = result
-        return inner
+    @staticmethod
+    def _response(status_code: int):
+        import requests
 
-    def test_span_success_records(self):
-        from opentelemetry.sdk.trace.export import SpanExportResult
+        resp = requests.Response()
+        resp.status_code = status_code
+        return resp
 
-        wrapper = _NetworkStatsSpanExporter(self._inner_span(SpanExportResult.SUCCESS))
-        self.assertEqual(wrapper.export([]), SpanExportResult.SUCCESS)
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {("otlp", "otlp.example.com"): 1})
+    def _make_span(self):
+        return _NetworkStatsSpanExporter(endpoint=self.SPAN_ENDPOINT)
 
-    def test_span_failure_does_not_record(self):
-        from opentelemetry.sdk.trace.export import SpanExportResult
+    def _make_metric(self):
+        return _NetworkStatsMetricExporter(endpoint=self.METRIC_ENDPOINT)
 
-        wrapper = _NetworkStatsSpanExporter(self._inner_span(SpanExportResult.FAILURE))
-        wrapper.export([])
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {})
+    def _make_log(self):
+        return _NetworkStatsLogExporter(endpoint=self.LOG_ENDPOINT)
 
-    def test_span_forwards_shutdown_and_force_flush(self):
-        from opentelemetry.sdk.trace.export import SpanExportResult
+    def _patch_super_export(self, cls, return_value=None, side_effect=None):
+        """Patch the upstream parent class's ``_export`` method."""
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-        inner = self._inner_span(SpanExportResult.SUCCESS)
-        inner.force_flush.return_value = True
-        wrapper = _NetworkStatsSpanExporter(inner)
-        wrapper.shutdown()
-        self.assertTrue(wrapper.force_flush(1234))
-        inner.shutdown.assert_called_once()
-        inner.force_flush.assert_called_once_with(1234)
+        parent_map = {
+            _NetworkStatsSpanExporter: OTLPSpanExporter,
+            _NetworkStatsMetricExporter: OTLPMetricExporter,
+            _NetworkStatsLogExporter: OTLPLogExporter,
+        }
+        return patch.object(
+            parent_map[cls],
+            "_export",
+            return_value=return_value,
+            side_effect=side_effect,
+        )
 
-    def test_metric_success_records(self):
-        from opentelemetry.sdk.metrics.export import MetricExportResult
+    # --------------------------- per-attempt classification (span exporter)
 
-        inner = MagicMock()
-        inner._endpoint = "https://otlp.example.com/v1/metrics"
-        inner._preferred_temporality = {}
-        inner._preferred_aggregation = {}
-        inner.export.return_value = MetricExportResult.SUCCESS
-        wrapper = _NetworkStatsMetricExporter(inner)
-        wrapper.export(MagicMock())
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {("otlp", "otlp.example.com"): 1})
+    def test_export_2xx_records_success(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(204)
+        ):
+            e._export(b"data", 1.0)
 
-    def test_metric_failure_does_not_record(self):
-        from opentelemetry.sdk.metrics.export import MetricExportResult
+        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {self.HOST_KEY: 1})
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {})
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {})
+        self.assertEqual(drain(REQUEST_THROTTLE_NAME), {})
+        self.assertEqual(drain(REQUEST_EXCEPTION_NAME), {})
 
-        inner = MagicMock()
-        inner._endpoint = "https://otlp.example.com/v1/metrics"
-        inner._preferred_temporality = {}
-        inner._preferred_aggregation = {}
-        inner.export.return_value = MetricExportResult.FAILURE
-        wrapper = _NetworkStatsMetricExporter(inner)
-        wrapper.export(MagicMock())
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {})
+    def test_export_throttle_402_records_throttle(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(402)
+        ):
+            e._export(b"data", 1.0)
 
-    def test_log_success_records(self):
-        from opentelemetry.sdk._logs.export import LogRecordExportResult
+        self.assertEqual(
+            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (402,): 1}
+        )
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {})
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {})
 
-        inner = MagicMock()
-        inner._endpoint = "https://otlp.example.com/v1/logs"
-        inner._host = "otlp"
-        inner.export.return_value = LogRecordExportResult.SUCCESS
-        wrapper = _NetworkStatsLogExporter(inner)
-        wrapper.export([])
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {("otlp", "otlp.example.com"): 1})
+    def test_export_throttle_439_records_throttle(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(439)
+        ):
+            e._export(b"data", 1.0)
 
-    def test_log_failure_does_not_record(self):
-        from opentelemetry.sdk._logs.export import LogRecordExportResult
+        self.assertEqual(
+            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (439,): 1}
+        )
 
-        inner = MagicMock()
-        inner._endpoint = "https://otlp.example.com/v1/logs"
-        inner.export.return_value = LogRecordExportResult.FAILURE
-        wrapper = _NetworkStatsLogExporter(inner)
-        wrapper.export([])
-        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {})
+    def test_export_retryable_429_records_retry(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(429)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {self.HOST_KEY + (429,): 1})
+        self.assertEqual(drain(REQUEST_THROTTLE_NAME), {})
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {})
+
+    def test_export_retryable_503_records_retry(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(503)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {self.HOST_KEY + (503,): 1})
+
+    def test_export_4xx_records_failure(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(404)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {self.HOST_KEY + (404,): 1})
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {})
+        self.assertEqual(drain(REQUEST_THROTTLE_NAME), {})
+
+    def test_export_5xx_non_retryable_records_failure(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(599)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {self.HOST_KEY + (599,): 1})
+
+    def test_export_inner_exception_records_exception_type_and_propagates(self):
+        import requests
+
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter,
+            side_effect=requests.ConnectionError("refused"),
+        ):
+            with self.assertRaises(requests.ConnectionError):
+                e._export(b"data", 1.0)
+
+        self.assertEqual(
+            drain(REQUEST_EXCEPTION_NAME),
+            {self.HOST_KEY + ("ConnectionError",): 1},
+        )
+        # Duration must still be recorded via the finally block.
+        _, count = drain(REQUEST_DURATION_NAME)[self.HOST_KEY]
+        self.assertEqual(count, 1)
+
+    def test_export_records_duration_per_attempt(self):
+        e = self._make_span()
+        with self._patch_super_export(
+            _NetworkStatsSpanExporter, return_value=self._response(204)
+        ):
+            e._export(b"data", 1.0)
+
+        duration = drain(REQUEST_DURATION_NAME)
+        self.assertEqual(set(duration.keys()), {self.HOST_KEY})
+        _, count = duration[self.HOST_KEY]
+        self.assertEqual(count, 1)
+
+    # ----------------------------------------------------- metric exporter
+
+    def test_metric_export_records_success(self):
+        e = self._make_metric()
+        with self._patch_super_export(
+            _NetworkStatsMetricExporter, return_value=self._response(204)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {self.HOST_KEY: 1})
+        _, count = drain(REQUEST_DURATION_NAME)[self.HOST_KEY]
+        self.assertEqual(count, 1)
+
+    def test_metric_export_records_retry_429(self):
+        e = self._make_metric()
+        with self._patch_super_export(
+            _NetworkStatsMetricExporter, return_value=self._response(429)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_RETRY_NAME), {self.HOST_KEY + (429,): 1})
+
+    def test_metric_export_records_failure_400(self):
+        e = self._make_metric()
+        with self._patch_super_export(
+            _NetworkStatsMetricExporter, return_value=self._response(400)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_FAILURE_NAME), {self.HOST_KEY + (400,): 1})
+
+    # -------------------------------------------------------- log exporter
+
+    def test_log_export_records_success(self):
+        e = self._make_log()
+        with self._patch_super_export(
+            _NetworkStatsLogExporter, return_value=self._response(204)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(drain(REQUEST_SUCCESS_NAME), {self.HOST_KEY: 1})
+
+    def test_log_export_records_throttle_402(self):
+        e = self._make_log()
+        with self._patch_super_export(
+            _NetworkStatsLogExporter, return_value=self._response(402)
+        ):
+            e._export(b"data", 1.0)
+
+        self.assertEqual(
+            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (402,): 1}
+        )
+
+    def test_log_export_records_exception_on_timeout(self):
+        import requests
+
+        e = self._make_log()
+        with self._patch_super_export(
+            _NetworkStatsLogExporter,
+            side_effect=requests.Timeout("timed out"),
+        ):
+            with self.assertRaises(requests.Timeout):
+                e._export(b"data", 1.0)
+
+        self.assertEqual(
+            drain(REQUEST_EXCEPTION_NAME),
+            {self.HOST_KEY + ("Timeout",): 1},
+        )
+
 
 
 if __name__ == "__main__":

--- a/tests/test_sdkstats.py
+++ b/tests/test_sdkstats.py
@@ -837,30 +837,6 @@ class TestNetworkStatsExporterWrappers(unittest.TestCase):
         self.assertEqual(drain(REQUEST_THROTTLE_NAME), {})
         self.assertEqual(drain(REQUEST_EXCEPTION_NAME), {})
 
-    def test_export_throttle_402_records_throttle(self):
-        e = self._make_span()
-        with self._patch_super_export(
-            _NetworkStatsSpanExporter, return_value=self._response(402)
-        ):
-            e._export(b"data", 1.0)
-
-        self.assertEqual(
-            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (402,): 1}
-        )
-        self.assertEqual(drain(REQUEST_FAILURE_NAME), {})
-        self.assertEqual(drain(REQUEST_RETRY_NAME), {})
-
-    def test_export_throttle_439_records_throttle(self):
-        e = self._make_span()
-        with self._patch_super_export(
-            _NetworkStatsSpanExporter, return_value=self._response(439)
-        ):
-            e._export(b"data", 1.0)
-
-        self.assertEqual(
-            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (439,): 1}
-        )
-
     def test_export_retryable_429_records_retry(self):
         e = self._make_span()
         with self._patch_super_export(
@@ -973,17 +949,6 @@ class TestNetworkStatsExporterWrappers(unittest.TestCase):
             e._export(b"data", 1.0)
 
         self.assertEqual(drain(REQUEST_SUCCESS_NAME), {self.HOST_KEY: 1})
-
-    def test_log_export_records_throttle_402(self):
-        e = self._make_log()
-        with self._patch_super_export(
-            _NetworkStatsLogExporter, return_value=self._response(402)
-        ):
-            e._export(b"data", 1.0)
-
-        self.assertEqual(
-            drain(REQUEST_THROTTLE_NAME), {self.HOST_KEY + (402,): 1}
-        )
 
     def test_log_export_records_exception_on_timeout(self):
         import requests


### PR DESCRIPTION
The public [export()](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py) API only returns a coarse SUCCESS/FAILURE and hides the HTTP status code, retries, and exceptions, so it can't drive per-attempt statsbeat classification (throttle vs retry vs failure vs exception). 

Overriding the OTLP exporters' internal _export() lets us hook the single point where the actual HTTP request happens, read response.status_code and any transport exception directly, and record duration plus the correct outcome per attempt — without re-implementing the exporter's serialization or retry logic.