### PR TITLE
Fix wrapt dep and change to positional arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "opentelemetry-instrumentation-openai-agents-v2==0.1.0",
     "opentelemetry-instrumentation-openai-v2==2.3b0",
     "opentelemetry-resource-detector-azure<1.0.0,>=0.1.5",
-    "wrapt>=1.0",
+    "wrapt>=1.0.0,<2.0.0",
     "opentelemetry-util-genai==0.3b0",
     "aiohttp>=3.8.0",
     "PyJWT",

--- a/src/microsoft/opentelemetry/_genai/_langchain/_tracer_instrumentor.py
+++ b/src/microsoft/opentelemetry/_genai/_langchain/_tracer_instrumentor.py
@@ -92,9 +92,9 @@ class LangChainInstrumentor(BaseInstrumentor):
 
         self._original_cb_init = langchain_core.callbacks.BaseCallbackManager.__init__
         wrap_function_wrapper(
-            module="langchain_core.callbacks",
-            name="BaseCallbackManager.__init__",
-            wrapper=_BaseCallbackManagerInit(self._tracer),
+            "langchain_core.callbacks",
+            "BaseCallbackManager.__init__",
+            _BaseCallbackManagerInit(self._tracer),
         )
 
         # Register the A365 span enricher when the A365 pipeline is available.


### PR DESCRIPTION
`wrapt` version > 2.0.0, introduces a breaking change which causes the openai-v2 and langchain instrumentations to fail as the argument name has been changed. To avoid future breaking changes, we make these arguments positional.

The reason why we pin the `wrapt` version is because we are using `opentelemetry-instrumentation-openai-v2==0.23b0` which is compatible with `opentelemetry-util-genai==0.3b0`. The latest version of openai-v2 does solve the wrapt version breaking change but it also pins to the latest version of util-genai, which introduces breaking changes for langchain, hence we will not adopt that version. If we do not pin `wrapt`, then the `openai-v2` will start to fail. 

We will upgrade all of this, once the new instrumentations in the genai repo are released and are in a stable state.