### PR TITLE
Add pre-commit hook for auto-formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# Pre-commit hooks for local development.
+#
+# Install once:
+#   pip install pre-commit
+#   pre-commit install
+#
+# After that, `git commit` automatically runs Black. If Black reformats any
+# file, the commit is aborted and the reformatted files are left in your
+# working tree as unstaged changes -- review them, `git add`, and commit again.
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3
+        # Match the paths the tox `black` env targets.
+        files: ^(src|tests|samples)/

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,5 +3,6 @@ pytest-asyncio>=0.23.0
 pytest-cov>=5.0
 pytest-benchmark>=4.0
 black>=24.0
+pre-commit>=3.5
 microsoft-agents-activity
 microsoft-agents-hosting-core


### PR DESCRIPTION
This PR introduces a pre-commit hook that automatically runs formatting fixes on modified files during each commit. Any formatting issues detected are fixed automatically before the commit is completed. Contributors can then review the changes and include the formatted files in their next commit.